### PR TITLE
fix: split game details from game

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Game.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Game.kt
@@ -1,12 +1,11 @@
 package com.esosa.f5pi_backend.data.models
 
-import com.esosa.f5pi_backend.controllers.responses.GameDetailsResponse
 import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
 import java.time.LocalDate
 import java.util.UUID
 
@@ -22,12 +21,11 @@ data class Game(
     @ManyToOne
     val user: User,
 
-    @OneToMany(mappedBy = "game", cascade = [CascadeType.ALL])
-    val teams: List<Team> = emptyList(),
+    @OneToOne(cascade = [CascadeType.ALL])
+    val details: GameDetails = GameDetails(),
 
     @Id
     val id: UUID = UUID.randomUUID()
 ) {
     fun buildGameResponse(): GameResponse = GameResponse(id, date, official, individualPrice, field.name)
-    fun buildGameDetailsResponse(): GameDetailsResponse = GameDetailsResponse(teams.map(Team::buildTeamResponse))
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/GameDetails.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/GameDetails.kt
@@ -1,0 +1,19 @@
+package com.esosa.f5pi_backend.data.models
+
+import com.esosa.f5pi_backend.controllers.responses.GameDetailsResponse
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
+import java.util.UUID
+
+@Entity
+data class GameDetails(
+    @OneToMany(mappedBy = "gameDetails", cascade = [CascadeType.ALL])
+    val teams: List<Team> = emptyList(),
+
+    @Id
+    val id: UUID = UUID.randomUUID()
+) {
+    fun buildGameDetailsResponse(): GameDetailsResponse = GameDetailsResponse(teams.map(Team::buildTeamResponse))
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Team.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Team.kt
@@ -13,7 +13,7 @@ data class Team(
     val winner: Boolean,
 
     @ManyToOne
-    val game: Game,
+    val gameDetails: GameDetails,
 
     @OneToMany(mappedBy = "team", cascade = [CascadeType.ALL])
     val members: List<Member> = emptyList(),

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IGameDetailsRepository.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IGameDetailsRepository.kt
@@ -1,0 +1,7 @@
+package com.esosa.f5pi_backend.data.repositories
+
+import com.esosa.f5pi_backend.data.models.GameDetails
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface IGameDetailsRepository: JpaRepository<GameDetails, UUID>

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
@@ -8,6 +8,7 @@ import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.data.models.Field
 import com.esosa.f5pi_backend.data.models.Game
 import com.esosa.f5pi_backend.data.models.User
+import com.esosa.f5pi_backend.data.repositories.IGameDetailsRepository
 import com.esosa.f5pi_backend.data.repositories.IGameRepository
 import com.esosa.f5pi_backend.services.interfaces.IFieldService
 import com.esosa.f5pi_backend.services.interfaces.IGameService
@@ -24,11 +25,13 @@ class GameService(
     private val gameRepository: IGameRepository,
     private val userService: IUserService,
     private val teamService: ITeamService,
-    private val fieldService: IFieldService
+    private val fieldService: IFieldService,
+    private val gameDetailsRepository: IGameDetailsRepository
 ) : IGameService {
 
     override fun getGameDetails(gameId: UUID): GameDetailsResponse =
         findGameByIdOrThrowException(gameId)
+            .details
             .buildGameDetailsResponse()
 
     override fun saveGame(createGameRequest: CreateGameRequest): GameResponse =
@@ -42,7 +45,8 @@ class GameService(
     override fun saveGameDetails(gameId: UUID, gameDetailsRequest: GameDetailsRequest) {
         findGameByIdOrThrowException(gameId).let { game ->
             gameDetailsRequest.teams
-                .forEach { teamRequest -> teamService.saveTeam(game, teamRequest, game.official, game.individualPrice) }
+                .forEach { teamRequest -> teamService.saveTeam(game.details, teamRequest, game.official, game.individualPrice) }
+            gameDetailsRepository.save(game.details)
         }
     }
 

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
@@ -46,7 +46,6 @@ class GameService(
         findGameByIdOrThrowException(gameId).let { game ->
             gameDetailsRequest.teams
                 .forEach { teamRequest -> teamService.saveTeam(game.details, teamRequest, game.official, game.individualPrice) }
-            gameDetailsRepository.save(game.details)
         }
     }
 

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
@@ -8,7 +8,6 @@ import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.data.models.Field
 import com.esosa.f5pi_backend.data.models.Game
 import com.esosa.f5pi_backend.data.models.User
-import com.esosa.f5pi_backend.data.repositories.IGameDetailsRepository
 import com.esosa.f5pi_backend.data.repositories.IGameRepository
 import com.esosa.f5pi_backend.services.interfaces.IFieldService
 import com.esosa.f5pi_backend.services.interfaces.IGameService
@@ -26,7 +25,6 @@ class GameService(
     private val userService: IUserService,
     private val teamService: ITeamService,
     private val fieldService: IFieldService,
-    private val gameDetailsRepository: IGameDetailsRepository
 ) : IGameService {
 
     override fun getGameDetails(gameId: UUID): GameDetailsResponse =

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/TeamService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/TeamService.kt
@@ -1,7 +1,7 @@
 package com.esosa.f5pi_backend.services.implementations
 
 import com.esosa.f5pi_backend.controllers.requests.TeamRequest
-import com.esosa.f5pi_backend.data.models.Game
+import com.esosa.f5pi_backend.data.models.GameDetails
 import com.esosa.f5pi_backend.data.models.Team
 import com.esosa.f5pi_backend.data.repositories.ITeamRepository
 import com.esosa.f5pi_backend.services.interfaces.IMemberService
@@ -14,12 +14,12 @@ class TeamService(
     private val memberService: IMemberService
 ) : ITeamService {
 
-    override fun saveTeam(game: Game, teamRequest: TeamRequest, official: Boolean, price: Double) {
-        teamRepository.save(teamRequest.buildTeam(game)).let { team ->
+    override fun saveTeam(gameDetails: GameDetails, teamRequest: TeamRequest, official: Boolean, price: Double) {
+        teamRepository.save(teamRequest.buildTeam(gameDetails)).let { team ->
             teamRequest.members
                 .forEach { memberRequest -> memberService.saveMember(team, memberRequest, teamRequest.winner, official, price) }
         }
     }
 
-    private fun TeamRequest.buildTeam(game: Game): Team = Team(winner, game)
+    private fun TeamRequest.buildTeam(gameDetails: GameDetails): Team = Team(winner, gameDetails)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/ITeamService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/ITeamService.kt
@@ -1,8 +1,8 @@
 package com.esosa.f5pi_backend.services.interfaces
 
 import com.esosa.f5pi_backend.controllers.requests.TeamRequest
-import com.esosa.f5pi_backend.data.models.Game
+import com.esosa.f5pi_backend.data.models.GameDetails
 
 interface ITeamService {
-    fun saveTeam(game: Game, teamRequest: TeamRequest, official: Boolean, price: Double)
+    fun saveTeam(gameDetails: GameDetails, teamRequest: TeamRequest, official: Boolean, price: Double)
 }


### PR DESCRIPTION
As we did in Player class, separating its statistics in another entity, I want to do the same thing with Game entity. 

The endpoints are not modified though, this is only an design decision, to keep the entities consistent with the controller layer. 