### PR TITLE
feat: refresh token

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthController.kt
@@ -2,7 +2,9 @@ package com.esosa.f5pi_backend.controllers.implementations
 
 import com.esosa.f5pi_backend.controllers.interfaces.IAuthController
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
+import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
 import com.esosa.f5pi_backend.services.interfaces.IAuthService
 import org.springframework.web.bind.annotation.RestController
 
@@ -13,4 +15,7 @@ class AuthController(private val authService: IAuthService) : IAuthController {
 
     override fun login(authRequest: AuthRequest): LoginResponse =
         authService.login(authRequest)
+
+    override fun refresh(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse =
+        authService.refreshToken(refreshTokenRequest)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IAuthController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IAuthController.kt
@@ -1,7 +1,9 @@
 package com.esosa.f5pi_backend.controllers.interfaces
 
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
+import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -24,6 +26,11 @@ interface IAuthController {
 
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "Authenticates a new user")
+    @Operation(summary = "Authenticates an existent user")
     fun login(@RequestBody @Valid authRequest: AuthRequest): LoginResponse
+
+    @PostMapping("/refresh")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Refreshes the access token for an existent user")
+    fun refresh(@RequestBody @Valid refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/RefreshTokenRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/RefreshTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.esosa.f5pi_backend.controllers.requests
+
+import jakarta.validation.constraints.NotBlank
+
+data class RefreshTokenRequest(
+    @field:NotBlank(message = "Refresh token must not be empty")
+    val refreshToken: String
+)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/LoginResponse.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/LoginResponse.kt
@@ -4,5 +4,6 @@ import java.util.UUID
 
 data class LoginResponse(
     val userId: UUID,
-    val accessToken: String
+    val accessToken: String,
+    val refreshToken: String
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/RefreshTokenResponse.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/RefreshTokenResponse.kt
@@ -1,0 +1,5 @@
+package com.esosa.f5pi_backend.controllers.responses
+
+data class RefreshTokenResponse(
+    val newAccessToken: String
+)

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTProperties.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTProperties.kt
@@ -5,5 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("jwt")
 data class JWTProperties(
     val key: String,
-    val accessTokenExpiration: Long
+    val accessTokenExpiration: Long,
+    val refreshTokenExpiration: Long
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
@@ -1,18 +1,22 @@
 package com.esosa.f5pi_backend.services.implementations
 
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
+import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
 import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.security.jwt.JWTProperties
 import com.esosa.f5pi_backend.security.jwt.JWTService
 import com.esosa.f5pi_backend.services.interfaces.IAuthService
 import com.esosa.f5pi_backend.services.interfaces.IUserService
+import org.springframework.http.HttpStatus
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
 import java.util.Date
 import java.util.UUID
 
@@ -39,14 +43,33 @@ class AuthService(
 
             val user = userDetailsService.loadUserByUsername(username)
             val accessToken = generateAccessToken(user)
+            val refreshToken = generateRefreshToken(user)
 
-            LoginResponse(username.extractId(), accessToken)
+            LoginResponse(username.extractId(), accessToken, refreshToken)
+        }
+
+    override fun refreshToken(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse =
+        with(refreshTokenRequest) {
+            jwtService.extractUsernameFromToken(refreshToken).let { username ->
+                val currentUserDetails = userDetailsService.loadUserByUsername(username)
+
+                if (!jwtService.isTokenValid(refreshToken, currentUserDetails))
+                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh token is not valid")
+
+                RefreshTokenResponse(generateAccessToken(currentUserDetails))
+            }
         }
 
     private fun generateAccessToken(userDetails: UserDetails): String =
         jwtService.generateToken(
             userDetails,
             Date(System.currentTimeMillis() + jwtProperties.accessTokenExpiration)
+        )
+
+    private fun generateRefreshToken(userDetails: UserDetails): String =
+        jwtService.generateToken(
+            userDetails,
+            Date(System.currentTimeMillis() + jwtProperties.refreshTokenExpiration)
         )
 
     private fun AuthRequest.buildUser(): User = User(username, passwordEncoder.encode(password))

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IAuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IAuthService.kt
@@ -1,9 +1,12 @@
 package com.esosa.f5pi_backend.services.interfaces
 
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
+import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
 
 interface IAuthService {
     fun register(authRequest: AuthRequest)
     fun login(authRequest: AuthRequest): LoginResponse
+    fun refreshToken(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,7 @@ spring:
 jwt:
   key: ${JWT_KEY:2CDFK2MJKLAM2KJCP2KLMCKJADJK2KLASMCJKD2KJKADKJJK2KCKJDS22}
   access-token-expiration: 3600000
+  refresh-token-expiration: 432000000
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
Added new mechanism to allow users to refresh their access token instead of logging in again. 

Refresh tokens are used to renew an already authenticated user's access token. 