### PR TITLE
feat: enable CORS

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/config/WebConfig.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/config/WebConfig.kt
@@ -1,0 +1,26 @@
+package com.esosa.f5pi_backend.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig {
+    @Value("\${cors.originPatterns:default}")
+    private val corsOriginPatterns: String = ""
+
+    @Bean
+    fun addCorsConfig(): WebMvcConfigurer {
+        return object : WebMvcConfigurer {
+            override fun addCorsMappings(registry: CorsRegistry) {
+                val allowedOrigins = corsOriginPatterns.split(",").toTypedArray()
+                registry.addMapping("/**")
+                    .allowedMethods("*")
+                    .allowedOriginPatterns(*allowedOrigins)
+                    .allowCredentials(true)
+            }
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,9 @@ spring:
     password: ${DB_PASSWORD:password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+cors:
+  originPatterns: ${CORS_ORIGINS:http://localhost:4200}
+
 jwt:
   key: ${JWT_KEY:2CDFK2MJKLAM2KJCP2KLMCKJADJK2KLASMCJKD2KJKADKJJK2KCKJDS22}
   access-token-expiration: 3600000


### PR DESCRIPTION
Se encontró un problema al intentar realizar peticiones POST desde un dominio del lado del cliente diferente al dominio en el que está corriendo el Back-end. Esta solución permite agregar la URL del Front-end como un origen habilitado para estas peticiones.

Es posible que exista una solución más óptima, ya que esta configuración la copie y pegue.