### PR TITLE
feat: retrieve user information from access token

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthController.kt
@@ -2,9 +2,11 @@ package com.esosa.f5pi_backend.controllers.implementations
 
 import com.esosa.f5pi_backend.controllers.interfaces.IAuthController
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.services.interfaces.IAuthService
 import org.springframework.web.bind.annotation.RestController
 
@@ -18,4 +20,7 @@ class AuthController(private val authService: IAuthService) : IAuthController {
 
     override fun refresh(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse =
         authService.refreshToken(refreshTokenRequest)
+
+    override fun checkToken(checkTokenRequest: CheckTokenRequest): UserResponse =
+        authService.checkToken(checkTokenRequest)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IAuthController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IAuthController.kt
@@ -1,9 +1,11 @@
 package com.esosa.f5pi_backend.controllers.interfaces
 
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -33,4 +35,9 @@ interface IAuthController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "Refreshes the access token for an existent user")
     fun refresh(@RequestBody @Valid refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse
+
+    @PostMapping("/check-token")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Retrieves user information over an access token")
+    fun checkToken(@RequestBody @Valid checkTokenRequest: CheckTokenRequest): UserResponse
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/CheckTokenRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/CheckTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.esosa.f5pi_backend.controllers.requests
+
+import jakarta.validation.constraints.NotBlank
+
+data class CheckTokenRequest(
+    @field:NotBlank(message = "Access token must not be empty")
+    val accessToken: String
+)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/LoginResponse.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/LoginResponse.kt
@@ -1,9 +1,7 @@
 package com.esosa.f5pi_backend.controllers.responses
 
-import java.util.UUID
-
 data class LoginResponse(
-    val userId: UUID,
+    val user: UserResponse,
     val accessToken: String,
     val refreshToken: String
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/UserResponse.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/UserResponse.kt
@@ -1,0 +1,9 @@
+package com.esosa.f5pi_backend.controllers.responses
+
+import java.util.UUID
+
+data class UserResponse(
+    val id: UUID,
+    val username: String,
+    val role: String
+)

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
@@ -1,8 +1,11 @@
 package com.esosa.f5pi_backend.data.models
 
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.data.enums.Role
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import java.util.UUID
@@ -28,4 +31,6 @@ data class User(
 
     @Id
     val id: UUID = UUID.randomUUID()
-)
+) {
+    fun buildUserResponse(): UserResponse = UserResponse(id, username, role.name)
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
@@ -1,9 +1,11 @@
 package com.esosa.f5pi_backend.services.implementations
 
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.security.jwt.JWTProperties
 import com.esosa.f5pi_backend.security.jwt.JWTService
@@ -18,7 +20,6 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import java.util.Date
-import java.util.UUID
 
 @Service
 class AuthService(
@@ -45,19 +46,25 @@ class AuthService(
             val accessToken = generateAccessToken(user)
             val refreshToken = generateRefreshToken(user)
 
-            LoginResponse(username.extractId(), accessToken, refreshToken)
+            LoginResponse(username.extractUser().buildUserResponse(), accessToken, refreshToken)
         }
 
     override fun refreshToken(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse =
         with(refreshTokenRequest) {
             jwtService.extractUsernameFromToken(refreshToken).let { username ->
                 val currentUserDetails = userDetailsService.loadUserByUsername(username)
-
-                if (!jwtService.isTokenValid(refreshToken, currentUserDetails))
-                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh token is not valid")
-
+                ifTokenInvalidThrowException(refreshToken, currentUserDetails)
                 RefreshTokenResponse(generateAccessToken(currentUserDetails))
             }
+        }
+
+    override fun checkToken(checkTokenRequest: CheckTokenRequest): UserResponse =
+        with(checkTokenRequest) {
+            val username = jwtService.extractUsernameFromToken(accessToken)
+            val userDetails = userDetailsService.loadUserByUsername(username)
+            ifTokenInvalidThrowException(accessToken, userDetails)
+            userService.findUserByUsernameOrThrowException(username)
+                .buildUserResponse()
         }
 
     private fun generateAccessToken(userDetails: UserDetails): String =
@@ -72,7 +79,12 @@ class AuthService(
             Date(System.currentTimeMillis() + jwtProperties.refreshTokenExpiration)
         )
 
+    private fun ifTokenInvalidThrowException(token: String, userDetails: UserDetails) {
+        if (!jwtService.isTokenValid(token, userDetails))
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh token is not valid")
+    }
+
     private fun AuthRequest.buildUser(): User = User(username, passwordEncoder.encode(password))
-    private fun String.extractId(): UUID = userService.findUserByUsernameOrThrowException(this).id
+    private fun String.extractUser(): User = userService.findUserByUsernameOrThrowException(this)
     private fun validateExistsUsername(username: String) = userService.ifExistsUsernameThrowException(username)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IAuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IAuthService.kt
@@ -1,12 +1,15 @@
 package com.esosa.f5pi_backend.services.interfaces
 
 import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 
 interface IAuthService {
     fun register(authRequest: AuthRequest)
     fun login(authRequest: AuthRequest): LoginResponse
     fun refreshToken(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse
+    fun checkToken(checkTokenRequest: CheckTokenRequest): UserResponse
 }


### PR DESCRIPTION
Added a new endpoint to retrieve user information from an access token. If the token is expired, the service will throw an exception.

Also, LoginResponse has changed. Instead of returning only the user ID, it will return an UserResponse objects which contains the ID, the username and the role.