### PR TITLE
feat: user data

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthController.kt
@@ -1,8 +1,9 @@
 package com.esosa.f5pi_backend.controllers.implementations
 
 import com.esosa.f5pi_backend.controllers.interfaces.IAuthController
-import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RegisterRequest
 import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
+import com.esosa.f5pi_backend.controllers.requests.LoginRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
@@ -12,11 +13,11 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class AuthController(private val authService: IAuthService) : IAuthController {
-    override fun register(authRequest: AuthRequest) =
-        authService.register(authRequest)
+    override fun register(registerRequest: RegisterRequest) =
+        authService.register(registerRequest)
 
-    override fun login(authRequest: AuthRequest): LoginResponse =
-        authService.login(authRequest)
+    override fun login(loginRequest: LoginRequest): LoginResponse =
+        authService.login(loginRequest)
 
     override fun refresh(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse =
         authService.refreshToken(refreshTokenRequest)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
@@ -1,10 +1,12 @@
 package com.esosa.f5pi_backend.controllers.implementations
 
 import com.esosa.f5pi_backend.controllers.interfaces.IUserController
+import com.esosa.f5pi_backend.controllers.requests.UpdateUserRequest
 import com.esosa.f5pi_backend.controllers.responses.FieldResponse
 import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.services.interfaces.IUserService
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
@@ -32,4 +34,10 @@ class UserController(private val userService: IUserService) : IUserController {
 
     override fun getUserSeasons(userId: UUID): List<SeasonResponse> =
         userService.getUserSeasons(userId)
+
+    override fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse =
+        userService.updateUser(userId, updateUserRequest)
+
+    override fun deleteUser(userId: UUID) =
+        userService.deleteUser(userId)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IAuthController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IAuthController.kt
@@ -1,7 +1,8 @@
 package com.esosa.f5pi_backend.controllers.interfaces
 
-import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RegisterRequest
 import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
+import com.esosa.f5pi_backend.controllers.requests.LoginRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
@@ -24,12 +25,12 @@ interface IAuthController {
     @PostMapping("/register")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "Registers a new user")
-    fun register(@RequestBody @Valid authRequest: AuthRequest)
+    fun register(@RequestBody @Valid registerRequest: RegisterRequest)
 
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "Authenticates an existent user")
-    fun login(@RequestBody @Valid authRequest: AuthRequest): LoginResponse
+    fun login(@RequestBody @Valid loginRequest: LoginRequest): LoginResponse
 
     @PostMapping("/refresh")
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
@@ -1,14 +1,19 @@
 package com.esosa.f5pi_backend.controllers.interfaces
 
+import com.esosa.f5pi_backend.controllers.requests.UpdateUserRequest
 import com.esosa.f5pi_backend.controllers.responses.FieldResponse
 import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -47,4 +52,14 @@ interface IUserController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Fetches a registered user seasons")
     fun getUserSeasons(@PathVariable userId: UUID): List<SeasonResponse>
+
+    @PatchMapping("/{userId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Updates a registered user data")
+    fun updateUser(@PathVariable userId: UUID, @RequestBody updateUserRequest: UpdateUserRequest): UserResponse
+
+    @DeleteMapping("/{userId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Deletes a registered user")
+    fun deleteUser(@PathVariable userId: UUID)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/AuthRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/AuthRequest.kt
@@ -1,5 +1,6 @@
 package com.esosa.f5pi_backend.controllers.requests
 
+import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
@@ -9,5 +10,11 @@ data class AuthRequest(
     val username: String,
 
     @field:NotBlank(message = "Password must not be empty")
-    val password: String
+    val password: String,
+
+    @field:NotBlank(message = "Name must not be empty")
+    val fullName: String,
+
+    @field:Email(message = "Invalid email format")
+    val email: String
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/LoginRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/LoginRequest.kt
@@ -1,20 +1,13 @@
 package com.esosa.f5pi_backend.controllers.requests
 
-import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
-data class AuthRequest(
+data class LoginRequest(
     @field:NotBlank(message = "Username must not be empty")
     @field:Size(max = 30, message = "Username must be less than 20 characters")
     val username: String,
 
     @field:NotBlank(message = "Password must not be empty")
-    val password: String,
-
-    @field:NotBlank(message = "Name must not be empty")
-    val fullName: String,
-
-    @field:Email(message = "Invalid email format")
-    val email: String
+    val password: String
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/RegisterRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/RegisterRequest.kt
@@ -1,0 +1,20 @@
+package com.esosa.f5pi_backend.controllers.requests
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class RegisterRequest(
+    @field:NotBlank(message = "Username must not be empty")
+    @field:Size(max = 30, message = "Username must be less than 20 characters")
+    val username: String,
+
+    @field:NotBlank(message = "Password must not be empty")
+    val password: String,
+
+    @field:NotBlank(message = "Name must not be empty")
+    val fullName: String,
+
+    @field:Email(message = "Invalid email format")
+    val email: String
+)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/UpdateUserRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/UpdateUserRequest.kt
@@ -1,0 +1,12 @@
+package com.esosa.f5pi_backend.controllers.requests
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateUserRequest(
+    @field:NotBlank(message = "Name must not be empty")
+    val fullName: String,
+
+    @field:Email(message = "Invalid email format")
+    val email: String
+)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/UserResponse.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/UserResponse.kt
@@ -5,5 +5,7 @@ import java.util.UUID
 data class UserResponse(
     val id: UUID,
     val username: String,
+    val fullName: String,
+    val email: String,
     val role: String
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
@@ -12,8 +12,8 @@ import java.util.UUID
 data class User(
     val username: String,
     val password: String,
-    val fullName: String,
-    val email: String,
+    var fullName: String,
+    var email: String,
 
     val role: Role = Role.USER,
 

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
@@ -4,8 +4,6 @@ import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.data.enums.Role
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import java.util.UUID
@@ -14,6 +12,8 @@ import java.util.UUID
 data class User(
     val username: String,
     val password: String,
+    val fullName: String,
+    val email: String,
 
     val role: Role = Role.USER,
 
@@ -32,5 +32,5 @@ data class User(
     @Id
     val id: UUID = UUID.randomUUID()
 ) {
-    fun buildUserResponse(): UserResponse = UserResponse(id, username, role.name)
+    fun buildUserResponse(): UserResponse = UserResponse(id, username, fullName, email, role.name)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
@@ -1,7 +1,8 @@
 package com.esosa.f5pi_backend.services.implementations
 
-import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RegisterRequest
 import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
+import com.esosa.f5pi_backend.controllers.requests.LoginRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
@@ -31,15 +32,15 @@ class AuthService(
     private val jwtProperties: JWTProperties
 ): IAuthService {
 
-    override fun register(authRequest: AuthRequest) {
-        with(authRequest) {
+    override fun register(registerRequest: RegisterRequest) {
+        with(registerRequest) {
             validateExistsUsername(username)
             userService.saveUser(buildUser())
         }
     }
 
-    override fun login(authRequest: AuthRequest): LoginResponse =
-        with(authRequest) {
+    override fun login(loginRequest: LoginRequest): LoginResponse =
+        with(loginRequest) {
             authManager.authenticate(UsernamePasswordAuthenticationToken(username, password))
 
             val user = userDetailsService.loadUserByUsername(username)
@@ -84,7 +85,7 @@ class AuthService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh token is not valid")
     }
 
-    private fun AuthRequest.buildUser(): User = User(username, passwordEncoder.encode(password), fullName, email)
+    private fun RegisterRequest.buildUser(): User = User(username, passwordEncoder.encode(password), fullName, email)
     private fun String.extractUser(): User = userService.findUserByUsernameOrThrowException(this)
     private fun validateExistsUsername(username: String) = userService.ifExistsUsernameThrowException(username)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
@@ -84,7 +84,7 @@ class AuthService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh token is not valid")
     }
 
-    private fun AuthRequest.buildUser(): User = User(username, passwordEncoder.encode(password))
+    private fun AuthRequest.buildUser(): User = User(username, passwordEncoder.encode(password), fullName, email)
     private fun String.extractUser(): User = userService.findUserByUsernameOrThrowException(this)
     private fun validateExistsUsername(username: String) = userService.ifExistsUsernameThrowException(username)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
@@ -1,9 +1,11 @@
 package com.esosa.f5pi_backend.services.implementations
 
+import com.esosa.f5pi_backend.controllers.requests.UpdateUserRequest
 import com.esosa.f5pi_backend.controllers.responses.FieldResponse
 import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.data.models.Field
 import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.models.Season
@@ -72,4 +74,23 @@ class UserService(
         findUserByIdOrThrowException(userId)
             .seasons
             .map(Season::buildSeasonResponse)
+
+    override fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse =
+        findUserByIdOrThrowException(userId).let { user ->
+            userRepository.save(
+                user.apply {
+                    fullName = updateUserRequest.fullName
+                    email = updateUserRequest.email
+                }).buildUserResponse()
+        }
+
+    override fun deleteUser(userId: UUID) {
+        ifUserDoesNotExistThrowException(userId)
+        userRepository.deleteById(userId)
+    }
+
+    private fun ifUserDoesNotExistThrowException(userId: UUID) {
+        if (!userRepository.existsById(userId))
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "User with id $userId does not exist")
+    }
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IAuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IAuthService.kt
@@ -1,15 +1,16 @@
 package com.esosa.f5pi_backend.services.interfaces
 
-import com.esosa.f5pi_backend.controllers.requests.AuthRequest
+import com.esosa.f5pi_backend.controllers.requests.RegisterRequest
 import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
+import com.esosa.f5pi_backend.controllers.requests.LoginRequest
 import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
 
 interface IAuthService {
-    fun register(authRequest: AuthRequest)
-    fun login(authRequest: AuthRequest): LoginResponse
+    fun register(registerRequest: RegisterRequest)
+    fun login(loginRequest: LoginRequest): LoginResponse
     fun refreshToken(refreshTokenRequest: RefreshTokenRequest): RefreshTokenResponse
     fun checkToken(checkTokenRequest: CheckTokenRequest): UserResponse
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
@@ -1,9 +1,11 @@
 package com.esosa.f5pi_backend.services.interfaces
 
+import com.esosa.f5pi_backend.controllers.requests.UpdateUserRequest
 import com.esosa.f5pi_backend.controllers.responses.FieldResponse
 import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
+import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.data.models.User
 import java.time.LocalDate
 import java.util.UUID
@@ -24,4 +26,6 @@ interface IUserService {
     ): List<GameResponse>
     fun getUserFields(userId: UUID): List<FieldResponse>
     fun getUserSeasons(userId: UUID): List<SeasonResponse>
+    fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse
+    fun deleteUser(userId: UUID)
 }


### PR DESCRIPTION
Previously, to sign up, users would only enter their usernames and their passwords. Now they have to provide more information such as their full name and their email. This information will be returned when the user logins in order to make the user profile more attractive.

Also, two endpoints were added: one to update the user information (only full name and email) and another to delete an user if the user wants to. Deleting an user will also delete his players, games, fields and seasons.