### PR TITLE
fix: parameter index mismatch in @Query

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IGameRepository.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IGameRepository.kt
@@ -14,8 +14,8 @@ interface IGameRepository: JpaRepository<Game, UUID> {
             "g.user = ?1 " +
             "AND (?2 is null or g.date >= ?2) " +
             "AND (?3 is null or g.date <= ?3) " +
-            "AND (?5 is null or g.field = ?4) " +
-            "AND (?6 is null or g.season = ?5)"
+            "AND (?4 is null or g.field = ?4) " +
+            "AND (?5 is null or g.season = ?5)"
     )
     fun findByUser(
         user: User,


### PR DESCRIPTION
When you made a request to the following URL: `http://localhost:8080/api/v1/users/{userId}/games`, it throw an error in console.

The error encountered was: `java.lang.IllegalArgumentException: At least 6 parameter(s) provided but only 5 parameter(s) present in query`. This error was caused by a mismatch between the number of parameters defined in the method and the parameters referenced in the  Query annotation.

By aligning the parameter indices correctly in the Query with the method parameters, I have resolved the issue.