### PR TITLE
feat: token type claim

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/data/enums/TokenType.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/enums/TokenType.kt
@@ -1,0 +1,6 @@
+package com.esosa.f5pi_backend.data.enums
+
+enum class TokenType {
+    ACCESS,
+    REFRESH
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/filter/JWTAuthenticationFilter.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/filter/JWTAuthenticationFilter.kt
@@ -37,7 +37,7 @@ class JWTAuthenticationFilter(
         if (SecurityContextHolder.getContext().authentication == null) {
             val user = userDetailsService.loadUserByUsername(username)
 
-            if (jwtService.isTokenValid(token, user))
+            if (jwtService.isTokenValid(token, user) && jwtService.extractTokenTypeFromToken(token)!! == "ACCESS")
                 updateContext(user, request)
 
             filterChain.doFilter(request, response)

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTService.kt
@@ -13,13 +13,12 @@ class JWTService(jwtProperties: JWTProperties) {
         jwtProperties.key.toByteArray()
     )
 
-    fun generateToken(userDetails: UserDetails, expirationDate: Date): String =
+    fun generateToken(userDetails: UserDetails, expirationDate: Date, extraClaims: Map<String, Any>): String =
         Jwts.builder()
-            .claims()
+            .claims(extraClaims)
             .subject(userDetails.username)
             .issuedAt(Date(System.currentTimeMillis()))
             .expiration(expirationDate)
-            .and()
             .signWith(secretKey)
             .compact()
 

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTService.kt
@@ -28,6 +28,9 @@ class JWTService(jwtProperties: JWTProperties) {
     fun isTokenValid(token: String, userDetails: UserDetails): Boolean =
         !isTokenExpired(token) && subjectEqualsUsername(token, userDetails)
 
+    fun extractTokenTypeFromToken(token: String) =
+        getAllClaimsFromToken(token)["tokenType"]
+
     private fun subjectEqualsUsername(token: String, userDetails: UserDetails): Boolean =
         getAllClaimsFromToken(token)
             .subject == userDetails.username

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
@@ -67,6 +67,7 @@ class AuthService(
             val username = jwtService.extractUsernameFromToken(accessToken)
             val userDetails = userDetailsService.loadUserByUsername(username)
             ifTokenInvalidThrowException(accessToken, userDetails)
+            ifNotAccessTokenThrowException(accessToken)
             userService.findUserByUsernameOrThrowException(username)
                 .buildUserResponse()
         }
@@ -96,6 +97,11 @@ class AuthService(
     private fun ifNotRefreshTokenThrowException(token: String) {
         if (jwtService.extractTokenTypeFromToken(token) != "REFRESH")
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is not a refresh token")
+    }
+
+    private fun ifNotAccessTokenThrowException(token: String) {
+        if (jwtService.extractTokenTypeFromToken(token) != "ACCESS")
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is not an access token")
     }
 
     private fun RegisterRequest.buildUser(): User = User(username, passwordEncoder.encode(password), fullName, email)

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
@@ -57,6 +57,7 @@ class AuthService(
             jwtService.extractUsernameFromToken(refreshToken).let { username ->
                 val currentUserDetails = userDetailsService.loadUserByUsername(username)
                 ifTokenInvalidThrowException(refreshToken, currentUserDetails)
+                ifNotRefreshTokenThrowException(refreshToken)
                 RefreshTokenResponse(generateAccessToken(currentUserDetails))
             }
         }
@@ -89,7 +90,12 @@ class AuthService(
 
     private fun ifTokenInvalidThrowException(token: String, userDetails: UserDetails) {
         if (!jwtService.isTokenValid(token, userDetails))
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh token is not valid")
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is not valid")
+    }
+
+    private fun ifNotRefreshTokenThrowException(token: String) {
+        if (jwtService.extractTokenTypeFromToken(token) != "REFRESH")
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Token is not a refresh token")
     }
 
     private fun RegisterRequest.buildUser(): User = User(username, passwordEncoder.encode(password), fullName, email)

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/AuthService.kt
@@ -7,6 +7,7 @@ import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.responses.LoginResponse
 import com.esosa.f5pi_backend.controllers.responses.RefreshTokenResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
+import com.esosa.f5pi_backend.data.enums.TokenType
 import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.security.jwt.JWTProperties
 import com.esosa.f5pi_backend.security.jwt.JWTService
@@ -72,14 +73,19 @@ class AuthService(
     private fun generateAccessToken(userDetails: UserDetails): String =
         jwtService.generateToken(
             userDetails,
-            Date(System.currentTimeMillis() + jwtProperties.accessTokenExpiration)
+            Date(System.currentTimeMillis() + jwtProperties.accessTokenExpiration),
+            generateTokenTypeClaim(TokenType.ACCESS)
         )
 
     private fun generateRefreshToken(userDetails: UserDetails): String =
         jwtService.generateToken(
             userDetails,
-            Date(System.currentTimeMillis() + jwtProperties.refreshTokenExpiration)
+            Date(System.currentTimeMillis() + jwtProperties.refreshTokenExpiration),
+            generateTokenTypeClaim(TokenType.REFRESH)
         )
+
+    private fun generateTokenTypeClaim(tokenType: TokenType): Map<String, Any> =
+        hashMapOf( Pair("tokenType", tokenType) )
 
     private fun ifTokenInvalidThrowException(token: String, userDetails: UserDetails) {
         if (!jwtService.isTokenValid(token, userDetails))


### PR DESCRIPTION
In order to difference access tokens from request tokens, the _tokenType_ claim was added. This is because refresh tokens should only be used to __create new access tokens__, meanwhile access tokens should only __authenticate the user__. The _tokenType_ claim allows to make these validations. This feature will not affect the model or the responses.