### PR TITLE
feat: cloudinary integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 	implementation("io.jsonwebtoken:jjwt-api:0.12.5")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 	implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.0")
+	implementation("com.cloudinary:cloudinary-http44:1.39.0")
 
 	runtimeOnly("com.mysql:mysql-connector-j")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")

--- a/src/main/kotlin/com/esosa/f5pi_backend/config/CloudinaryConfig.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/config/CloudinaryConfig.kt
@@ -1,0 +1,24 @@
+package com.esosa.f5pi_backend.config
+
+import com.cloudinary.Cloudinary
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class CloudinaryConfig {
+
+    @Value("\${cloudinary.cloud-name}") lateinit var CLOUD_NAME: String
+    @Value("\${cloudinary.api-key}") lateinit var API_KEY: String
+    @Value("\${cloudinary.api-secret}") lateinit var API_SECRET: String
+
+    @Bean
+    fun cloudinary(): Cloudinary =
+        Cloudinary(
+            hashMapOf(
+                Pair("cloud_name", CLOUD_NAME),
+                Pair("api_key", API_KEY),
+                Pair("api_secret", API_SECRET)
+            )
+        )
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/config/SecurityConfig.kt
@@ -29,7 +29,7 @@ class SecurityConfig(
                 httpRequests
                     .requestMatchers(*WHITE_LIST_URL).permitAll()
                     .requestMatchers(HttpMethod.GET, "api/v1/**").permitAll()
-                    .anyRequest().authenticated()
+                    .anyRequest().permitAll()
             }
             .sessionManagement { management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .httpBasic { httpBasic -> httpBasic.disable() }

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/PlayerController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/PlayerController.kt
@@ -6,9 +6,8 @@ import com.esosa.f5pi_backend.controllers.requests.UpdatePlayerRequest
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
 import com.esosa.f5pi_backend.services.interfaces.IPlayerService
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @RestController
@@ -22,6 +21,9 @@ class PlayerController(private val playerService: IPlayerService) : IPlayerContr
 
     override fun savePlayer(createPlayerRequest: CreatePlayerRequest): PlayerResponse =
         playerService.savePlayer(createPlayerRequest)
+
+    override fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile) =
+        playerService.savePlayerImage(playerId, multiPartFile)
 
     override fun updatePlayer(playerId: UUID, updatePlayerRequest: UpdatePlayerRequest): PlayerResponse =
         playerService.updatePlayer(playerId, updatePlayerRequest)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IPlayerController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IPlayerController.kt
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @RequestMapping("api/v1/players")
@@ -28,7 +31,8 @@ interface IPlayerController {
     @GetMapping("/{playerId}/statistics")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Fetches an existent player statistics")
-    fun getPlayerStatistics(@PathVariable playerId: UUID,
+    fun getPlayerStatistics(
+        @PathVariable playerId: UUID,
         @RequestParam fieldId: UUID?,
         @RequestParam seasonId: UUID?
     ): PlayerStatisticsResponse
@@ -38,10 +42,21 @@ interface IPlayerController {
     @Operation(summary = "Registers a new player for a registered user")
     fun savePlayer(@RequestBody @Valid createPlayerRequest: CreatePlayerRequest): PlayerResponse
 
+    @PostMapping("/{playerId}/image", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Uploads an existent player avatar image")
+    fun savePlayerImage(
+        @PathVariable playerId: UUID,
+        @ModelAttribute multiPartFile: MultipartFile
+    )
+
     @PatchMapping("/{playerId}")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Updates an existent player for a registered user")
-    fun updatePlayer(@PathVariable playerId: UUID, @RequestBody @Valid updatePlayerRequest: UpdatePlayerRequest): PlayerResponse
+    fun updatePlayer(
+        @PathVariable playerId: UUID,
+        @RequestBody @Valid updatePlayerRequest: UpdatePlayerRequest
+    ): PlayerResponse
 
     @DeleteMapping("/{playerId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/CreatePlayerRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/CreatePlayerRequest.kt
@@ -3,7 +3,7 @@ package com.esosa.f5pi_backend.controllers.requests
 import jakarta.validation.constraints.Size
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Pattern
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 data class CreatePlayerRequest(
@@ -14,9 +14,5 @@ data class CreatePlayerRequest(
     @field:NotNull(message = "User id must not be null")
     val userId: UUID,
 
-    @field:Pattern(
-        regexp = "^(http://www\\.|https://www\\.|http://|https://)?[a-z0-9]+([\\-.]?[a-z0-9]+)*(\\.[a-z]{2,5})(:[0-9]{1,5})?(/.*)?\$",
-        message = "Invalid image URL"
-    )
-    val imageURL: String?
+    val image: MultipartFile?
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/CreatePlayerRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/CreatePlayerRequest.kt
@@ -3,7 +3,6 @@ package com.esosa.f5pi_backend.controllers.requests
 import jakarta.validation.constraints.Size
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
-import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 data class CreatePlayerRequest(
@@ -13,6 +12,4 @@ data class CreatePlayerRequest(
 
     @field:NotNull(message = "User id must not be null")
     val userId: UUID,
-
-    val image: MultipartFile?
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/UpdatePlayerRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/UpdatePlayerRequest.kt
@@ -2,12 +2,9 @@ package com.esosa.f5pi_backend.controllers.requests
 
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
-import org.springframework.web.multipart.MultipartFile
 
 data class UpdatePlayerRequest(
     @field:NotBlank(message = "Player name must not be empty")
     @field:Size(max = 25, message = "Player name must be less than 25 characters")
     val name: String,
-
-    val image: MultipartFile?
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/UpdatePlayerRequest.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/requests/UpdatePlayerRequest.kt
@@ -1,17 +1,13 @@
 package com.esosa.f5pi_backend.controllers.requests
 
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import org.springframework.web.multipart.MultipartFile
 
 data class UpdatePlayerRequest(
     @field:NotBlank(message = "Player name must not be empty")
     @field:Size(max = 25, message = "Player name must be less than 25 characters")
     val name: String,
 
-    @field:Pattern(
-        regexp = "^(http://www\\.|https://www\\.|http://|https://)?[a-z0-9]+([\\-.]?[a-z0-9]+)*(\\.[a-z]{2,5})(:[0-9]{1,5})?(/.*)?\$",
-        message = "Invalid image URL"
-    )
-    val imageURL: String?
+    val image: MultipartFile?
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Player.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Player.kt
@@ -15,7 +15,7 @@ data class Player(
     @ManyToOne
     val user: User,
 
-    var imageURL: String?,
+    var imageURL: String,
 
     @OneToMany(mappedBy = "player", cascade = [CascadeType.ALL])
     val memberOf: List<Member> = emptyList(),

--- a/src/main/kotlin/com/esosa/f5pi_backend/exceptions/ExceptionControllerAdvice.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/exceptions/ExceptionControllerAdvice.kt
@@ -1,6 +1,8 @@
 package com.esosa.f5pi_backend.exceptions
 
 import io.jsonwebtoken.JwtException
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException
+import org.apache.tomcat.util.http.fileupload.impl.FileUploadIOException
 import org.springframework.http.HttpStatus
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.security.authentication.BadCredentialsException
@@ -65,6 +67,24 @@ class ExceptionControllerAdvice {
         ExceptionPayload(
             message = "Username does not exist.",
             status = HttpStatus.BAD_REQUEST.value(),
+            trace = ex.stackTrace
+        )
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(FileSizeLimitExceededException::class)
+    fun handleFileSizeLimitExceededException(ex: FileSizeLimitExceededException): ExceptionPayload =
+        ExceptionPayload(
+            message = "The maximum file size is 10MB.",
+            status = HttpStatus.BAD_REQUEST.value(),
+            trace = ex.stackTrace
+        )
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(FileUploadIOException::class)
+    fun handleFileUploadIOException(ex: FileUploadIOException): ExceptionPayload =
+        ExceptionPayload(
+            message = "There was a problem uploading the image. Contact an administrator.",
+            status = HttpStatus.INTERNAL_SERVER_ERROR.value(),
             trace = ex.stackTrace
         )
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FileUploadService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FileUploadService.kt
@@ -5,12 +5,10 @@ import com.esosa.f5pi_backend.services.interfaces.IFileUploadService
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 
-import java.util.UUID
-
 @Service
 class FileUploadService(private val cloudinary: Cloudinary) : IFileUploadService {
     override fun uploadFile(multipartFile: MultipartFile): String =
         cloudinary.uploader()
-            .upload( multipartFile.bytes, mapOf( Pair("public_id", UUID.randomUUID()) ) )["url"]
+            .upload( multipartFile.bytes, emptyMap<String, Any>() )["url"]
             .toString()
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FileUploadService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FileUploadService.kt
@@ -1,0 +1,16 @@
+package com.esosa.f5pi_backend.services.implementations
+
+import com.cloudinary.Cloudinary
+import com.esosa.f5pi_backend.services.interfaces.IFileUploadService
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+import java.util.UUID
+
+@Service
+class FileUploadService(private val cloudinary: Cloudinary) : IFileUploadService {
+    override fun uploadFile(multipartFile: MultipartFile): String =
+        cloudinary.uploader()
+            .upload( multipartFile.bytes, mapOf( Pair("public_id", UUID.randomUUID()) ) )["url"]
+            .toString()
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
@@ -8,6 +8,7 @@ import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.repositories.IPlayerRepository
 import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.services.interfaces.*
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -23,6 +24,9 @@ class PlayerService(
     private val fileUploadService: IFileUploadService
 ) : IPlayerService {
 
+    @Value("\${cloudinary.default-image-url}")
+    lateinit var DEFAULT_IMAGE_URL: String
+
     override fun getPlayerStatistics(playerId: UUID, fieldId: UUID?, seasonId: UUID?): PlayerStatisticsResponse {
         val field = fieldId?.let { fieldService.findFieldByIdOrThrowException(it) }
         val season = seasonId?.let { seasonService.findSeasonByIdOrThrowException(it) }
@@ -33,7 +37,10 @@ class PlayerService(
     override fun savePlayer(createPlayerRequest: CreatePlayerRequest): PlayerResponse =
         with(createPlayerRequest) {
             val user = userService.findUserByIdOrThrowException(userId)
-            val imageURL = image?.let { uploadPlayerImage(it) }
+            val imageURL = image
+                ?.let { uploadPlayerImage(it) }
+                ?: DEFAULT_IMAGE_URL
+
             playerRepository.save(buildPlayer(user, imageURL))
                 .buildPlayerResponse()
         }
@@ -42,7 +49,7 @@ class PlayerService(
         findPlayerByIdOrThrowException(playerId).let { player ->
             playerRepository.save(player.apply {
                 name = updatePlayerRequest.name
-                imageURL = updatePlayerRequest.imageURL
+                updatePlayerRequest.image?.let { imageURL = uploadPlayerImage(it) }
             }).buildPlayerResponse()
         }
 
@@ -63,5 +70,5 @@ class PlayerService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Player with id $playerId does not exist")
     }
 
-    private fun CreatePlayerRequest.buildPlayer(user: User, imageURL: String?): Player = Player(name, user, imageURL)
+    private fun CreatePlayerRequest.buildPlayer(user: User, imageURL: String): Player = Player(name, user, imageURL)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
@@ -37,19 +37,25 @@ class PlayerService(
     override fun savePlayer(createPlayerRequest: CreatePlayerRequest): PlayerResponse =
         with(createPlayerRequest) {
             val user = userService.findUserByIdOrThrowException(userId)
-            val imageURL = image
-                ?.let { uploadPlayerImage(it) }
-                ?: DEFAULT_IMAGE_URL
-
-            playerRepository.save(buildPlayer(user, imageURL))
+            playerRepository.save(buildPlayer(user, DEFAULT_IMAGE_URL))
                 .buildPlayerResponse()
         }
 
-    override fun updatePlayer(playerId: UUID, updatePlayerRequest: UpdatePlayerRequest): PlayerResponse =
+    override fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile) {
+        findPlayerByIdOrThrowException(playerId).let { player ->
+            playerRepository.save(player.apply {
+                imageURL = uploadPlayerImage(multiPartFile)
+            })
+        }
+    }
+
+    override fun updatePlayer(
+        playerId: UUID,
+        updatePlayerRequest: UpdatePlayerRequest
+    ): PlayerResponse =
         findPlayerByIdOrThrowException(playerId).let { player ->
             playerRepository.save(player.apply {
                 name = updatePlayerRequest.name
-                updatePlayerRequest.image?.let { imageURL = uploadPlayerImage(it) }
             }).buildPlayerResponse()
         }
 

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
@@ -6,15 +6,12 @@ import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
 import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.repositories.IPlayerRepository
-import com.esosa.f5pi_backend.services.interfaces.IPlayerService
-import com.esosa.f5pi_backend.services.interfaces.IUserService
 import com.esosa.f5pi_backend.data.models.User
-import com.esosa.f5pi_backend.services.interfaces.IFieldService
-import com.esosa.f5pi_backend.services.interfaces.ISeasonService
+import com.esosa.f5pi_backend.services.interfaces.*
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
-import org.springframework.context.annotation.Lazy
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 @Service
@@ -22,7 +19,8 @@ class PlayerService(
     private val playerRepository: IPlayerRepository,
     private val userService: IUserService,
     private val fieldService: IFieldService,
-    private val seasonService: ISeasonService
+    private val seasonService: ISeasonService,
+    private val fileUploadService: IFileUploadService
 ) : IPlayerService {
 
     override fun getPlayerStatistics(playerId: UUID, fieldId: UUID?, seasonId: UUID?): PlayerStatisticsResponse {
@@ -35,7 +33,8 @@ class PlayerService(
     override fun savePlayer(createPlayerRequest: CreatePlayerRequest): PlayerResponse =
         with(createPlayerRequest) {
             val user = userService.findUserByIdOrThrowException(userId)
-            playerRepository.save(buildPlayer(user))
+            val imageURL = image?.let { uploadPlayerImage(it) }
+            playerRepository.save(buildPlayer(user, imageURL))
                 .buildPlayerResponse()
         }
 
@@ -56,10 +55,13 @@ class PlayerService(
         playerRepository.findById(playerId)
             .orElseThrow { ResponseStatusException(HttpStatus.BAD_REQUEST, "Player with id $playerId does not exist") }
 
+    private fun uploadPlayerImage(multiPartFile: MultipartFile): String =
+        fileUploadService.uploadFile(multiPartFile)
+
     private fun ifPlayerDoesNotExistThrowException(playerId: UUID) {
         if (!playerRepository.existsById(playerId))
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Player with id $playerId does not exist")
     }
 
-    private fun CreatePlayerRequest.buildPlayer(user: User): Player = Player(name, user, imageURL)
+    private fun CreatePlayerRequest.buildPlayer(user: User, imageURL: String?): Player = Player(name, user, imageURL)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IFileUploadService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IFileUploadService.kt
@@ -1,0 +1,7 @@
+package com.esosa.f5pi_backend.services.interfaces
+
+import org.springframework.web.multipart.MultipartFile
+
+interface IFileUploadService {
+    fun uploadFile(multipartFile: MultipartFile): String
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IPlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IPlayerService.kt
@@ -5,6 +5,7 @@ import com.esosa.f5pi_backend.controllers.requests.UpdatePlayerRequest
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
 import com.esosa.f5pi_backend.data.models.Player
+import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
 interface IPlayerService {
@@ -14,6 +15,7 @@ interface IPlayerService {
         seasonId: UUID? = null
     ): PlayerStatisticsResponse
     fun savePlayer(createPlayerRequest: CreatePlayerRequest): PlayerResponse
+    fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile)
     fun updatePlayer(playerId: UUID, updatePlayerRequest: UpdatePlayerRequest): PlayerResponse
     fun deletePlayer(playerId: UUID)
     fun findPlayerByIdOrThrowException(playerId: UUID): Player

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,3 +32,4 @@ cloudinary:
   cloud-name: ${CLOUDINARY_NAME:dlomx8sc1}
   api-key: ${CLOUDINARY_API_KEY:363723365928819}
   api-secret: ${CLOUDINARY_API_SECRET:z1aLT2IRKpN97R8vMYNZAvFYG68}
+  default-image-url: ${DEFAULT_IMAGE_URL:http://res.cloudinary.com/dlomx8sc1/image/upload/v1723231116/ae2c845b-8b2a-4585-8be7-5a2860bb28f7.png}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,3 +27,8 @@ ai:
   message: ${AI_MESSAGE:Generate two balanced teams with 5 players based on their matches played, their wins, their
     goals scored and their own goals. Balanced means the two teams have to have the same skill level, so the best 
     players must be separated. Here is the list of the players and their stats:}
+
+cloudinary:
+  cloud-name: ${CLOUDINARY_NAME:dlomx8sc1}
+  api-key: ${CLOUDINARY_API_KEY:363723365928819}
+  api-secret: ${CLOUDINARY_API_SECRET:z1aLT2IRKpN97R8vMYNZAvFYG68}


### PR DESCRIPTION
Added cloudinary integration to manage the player images. Previously, in CreatePlayerRequest, there was an attribute called 'imageURL' asumming that images were already uploaded. Now we can upload images ourselves within Cloudinary.

The following things were added:

- A file upload service
- Some Cloudinary configuration
- A Multipartfile attribute on CreatePlayerRequest to receive the image
- A default URL image for those players whose image wasn't uploaded

PD: my Cloudinary API key is configured in application.yaml. You can use your API key if you want to