### PR TITLE
ref: responses info

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package com.esosa.f5pi_backend.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/GameController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/GameController.kt
@@ -18,7 +18,7 @@ class GameController(private val gameService: IGameService) : IGameController {
     override fun saveGame(createGameRequest: CreateGameRequest): GameResponse =
         gameService.saveGame(createGameRequest)
 
-    override fun saveGameDetails(gameId: UUID, gameDetailsRequest: GameDetailsRequest) =
+    override fun saveGameDetails(gameId: UUID, gameDetailsRequest: GameDetailsRequest): GameDetailsResponse =
         gameService.saveGameDetails(gameId, gameDetailsRequest)
 
     override fun updateGame(gameId: UUID, updateGameRequest: UpdateGameRequest): GameResponse =

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/PlayerController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/PlayerController.kt
@@ -5,6 +5,7 @@ import com.esosa.f5pi_backend.controllers.requests.CreatePlayerRequest
 import com.esosa.f5pi_backend.controllers.requests.UpdatePlayerRequest
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
+import com.esosa.f5pi_backend.controllers.responses.SavePlayerImageResponse
 import com.esosa.f5pi_backend.services.interfaces.IPlayerService
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -22,7 +23,7 @@ class PlayerController(private val playerService: IPlayerService) : IPlayerContr
     override fun savePlayer(createPlayerRequest: CreatePlayerRequest): PlayerResponse =
         playerService.savePlayer(createPlayerRequest)
 
-    override fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile) =
+    override fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile): SavePlayerImageResponse =
         playerService.savePlayerImage(playerId, multiPartFile)
 
     override fun updatePlayer(playerId: UUID, updatePlayerRequest: UpdatePlayerRequest): PlayerResponse =

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IGameController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IGameController.kt
@@ -38,7 +38,7 @@ interface IGameController {
     @PostMapping("/{gameId}/detail")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "Registers the details of an existent game")
-    fun saveGameDetails(@PathVariable gameId: UUID, @RequestBody @Valid gameDetailsRequest: GameDetailsRequest)
+    fun saveGameDetails(@PathVariable gameId: UUID, @RequestBody @Valid gameDetailsRequest: GameDetailsRequest): GameDetailsResponse
 
     @PatchMapping("/{gameId}")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IPlayerController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IPlayerController.kt
@@ -4,6 +4,7 @@ import com.esosa.f5pi_backend.controllers.requests.CreatePlayerRequest
 import com.esosa.f5pi_backend.controllers.requests.UpdatePlayerRequest
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
+import com.esosa.f5pi_backend.controllers.responses.SavePlayerImageResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -48,7 +49,7 @@ interface IPlayerController {
     fun savePlayerImage(
         @PathVariable playerId: UUID,
         @ModelAttribute multiPartFile: MultipartFile
-    )
+    ): SavePlayerImageResponse
 
     @PatchMapping("/{playerId}")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/MemberResponse.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/MemberResponse.kt
@@ -2,6 +2,7 @@ package com.esosa.f5pi_backend.controllers.responses
 
 data class MemberResponse(
     val playerName: String,
+    val imageURL: String,
     val goalsScored: Int,
     val ownGoals: Int
 )

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/SavePlayerImageResponse.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/responses/SavePlayerImageResponse.kt
@@ -1,0 +1,5 @@
+package com.esosa.f5pi_backend.controllers.responses
+
+data class SavePlayerImageResponse(
+    val imageURL: String
+)

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/GameDetails.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/GameDetails.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 @Entity
 data class GameDetails(
     @OneToMany(mappedBy = "gameDetails", cascade = [CascadeType.ALL])
-    val teams: List<Team> = emptyList(),
+    val teams: MutableList<Team> = mutableListOf(),
 
     @Id
     val id: UUID = UUID.randomUUID()

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Member.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Member.kt
@@ -20,5 +20,5 @@ data class Member(
     @Id
     val id: UUID = UUID.randomUUID()
 ) {
-    fun buildMemberResponse(): MemberResponse = MemberResponse(player.name, goalsScored, ownGoals)
+    fun buildMemberResponse(): MemberResponse = MemberResponse(player.name, player.imageURL, goalsScored, ownGoals)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Team.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Team.kt
@@ -21,7 +21,7 @@ data class Team(
     val gameDetails: GameDetails,
 
     @OneToMany(mappedBy = "team", cascade = [CascadeType.ALL])
-    val members: List<Member> = emptyList(),
+    val members: MutableList<Member> = mutableListOf(),
 
     @Id
     val id: UUID = UUID.randomUUID()

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
@@ -48,7 +48,7 @@ class GameService(
                 .buildGameResponse()
         }
 
-    override fun saveGameDetails(gameId: UUID, gameDetailsRequest: GameDetailsRequest) {
+    override fun saveGameDetails(gameId: UUID, gameDetailsRequest: GameDetailsRequest): GameDetailsResponse {
         ifMembersSizeFromTeamDoesNotEqualThrowException(gameDetailsRequest)
 
         val game = findGameByIdOrThrowException(gameId)
@@ -58,6 +58,9 @@ class GameService(
         gameDetailsRequest.teams.forEachIndexed { index, team ->
             teamService.saveTeam(game.details, teamResults.toList()[index], teamGoals.toList()[index], team)
         }
+
+        return game.details
+            .buildGameDetailsResponse()
     }
 
     override fun updateGame(gameId: UUID, updateGameRequest: UpdateGameRequest): GameResponse =

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/MemberService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/MemberService.kt
@@ -7,6 +7,7 @@ import com.esosa.f5pi_backend.data.models.Team
 import com.esosa.f5pi_backend.data.repositories.IMemberRepository
 import com.esosa.f5pi_backend.services.interfaces.IMemberService
 import com.esosa.f5pi_backend.services.interfaces.IPlayerService
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 
 @Service
@@ -18,6 +19,12 @@ class MemberService(
     override fun saveMember(team: Team, memberRequest: MemberRequest) {
         val player = playerService.findPlayerByIdOrThrowException(memberRequest.playerId)
         memberRepository.save(memberRequest.buildMember(team, player))
+            .also { updateTeam(it, team) }
+    }
+
+    @Async
+    private fun updateTeam(member: Member, team: Team) {
+        team.members.add(member)
     }
 
     private fun MemberRequest.buildMember(team: Team, player: Player): Member = Member(goalsScored, ownGoals, team, player)

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
@@ -4,6 +4,7 @@ import com.esosa.f5pi_backend.controllers.requests.CreatePlayerRequest
 import com.esosa.f5pi_backend.controllers.requests.UpdatePlayerRequest
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
+import com.esosa.f5pi_backend.controllers.responses.SavePlayerImageResponse
 import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.repositories.IPlayerRepository
 import com.esosa.f5pi_backend.data.models.User
@@ -41,13 +42,12 @@ class PlayerService(
                 .buildPlayerResponse()
         }
 
-    override fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile) {
+    override fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile): SavePlayerImageResponse =
         findPlayerByIdOrThrowException(playerId).let { player ->
-            playerRepository.save(player.apply {
-                imageURL = uploadPlayerImage(multiPartFile)
-            })
+            val imageURL = uploadPlayerImage(multiPartFile)
+            playerRepository.save(player.apply { this.imageURL = imageURL })
+            return@let SavePlayerImageResponse(imageURL)
         }
-    }
 
     override fun updatePlayer(
         playerId: UUID,

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/TeamService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/TeamService.kt
@@ -7,6 +7,7 @@ import com.esosa.f5pi_backend.data.models.Team
 import com.esosa.f5pi_backend.data.repositories.ITeamRepository
 import com.esosa.f5pi_backend.services.interfaces.IMemberService
 import com.esosa.f5pi_backend.services.interfaces.ITeamService
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
 
 @Service
@@ -16,12 +17,18 @@ class TeamService(
 ) : ITeamService {
 
     override fun saveTeam(gameDetails: GameDetails, teamResult: TeamResult, teamGoals: Int, teamRequest: TeamRequest) {
-        teamRepository.save(buildTeam(teamResult, teamGoals, gameDetails)).let { team ->
-            teamRequest.members
-                .forEach { memberRequest -> memberService.saveMember(team, memberRequest) }
+        teamRepository.save(buildTeam(teamResult, teamGoals, gameDetails))
+            .also { updateGameDetails(it, gameDetails) }
+            .let { team -> teamRequest.members
+                    .forEach { memberRequest -> memberService.saveMember(team, memberRequest) }
         }
     }
 
     private fun buildTeam(teamResult: TeamResult, teamGoals: Int, gameDetails: GameDetails): Team =
         Team(teamResult, teamGoals, gameDetails)
+
+    @Async
+    private fun updateGameDetails(team: Team, gameDetails: GameDetails) {
+        gameDetails.teams.add(team)
+    }
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IGameService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IGameService.kt
@@ -15,7 +15,7 @@ import java.util.UUID
 interface IGameService {
     fun getGameDetails(gameId: UUID): GameDetailsResponse
     fun saveGame(createGameRequest: CreateGameRequest): GameResponse
-    fun saveGameDetails(gameId: UUID, gameDetailsRequest: GameDetailsRequest)
+    fun saveGameDetails(gameId: UUID, gameDetailsRequest: GameDetailsRequest): GameDetailsResponse
     fun updateGame(gameId: UUID, updateGameRequest: UpdateGameRequest): GameResponse
     fun deleteGame(gameId: UUID)
     fun findGameByIdOrThrowException(gameId: UUID): Game

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IPlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IPlayerService.kt
@@ -4,6 +4,7 @@ import com.esosa.f5pi_backend.controllers.requests.CreatePlayerRequest
 import com.esosa.f5pi_backend.controllers.requests.UpdatePlayerRequest
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
+import com.esosa.f5pi_backend.controllers.responses.SavePlayerImageResponse
 import com.esosa.f5pi_backend.data.models.Player
 import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
@@ -15,7 +16,7 @@ interface IPlayerService {
         seasonId: UUID? = null
     ): PlayerStatisticsResponse
     fun savePlayer(createPlayerRequest: CreatePlayerRequest): PlayerResponse
-    fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile)
+    fun savePlayerImage(playerId: UUID, multiPartFile: MultipartFile): SavePlayerImageResponse
     fun updatePlayer(playerId: UUID, updatePlayerRequest: UpdatePlayerRequest): PlayerResponse
     fun deletePlayer(playerId: UUID)
     fun findPlayerByIdOrThrowException(playerId: UUID): Player


### PR DESCRIPTION
These are just simple changes meant to ease the data-retrieving from the frontend, avoiding multiple requests. The following things were added:

- URL image attribute on MemberResponse
- GameDetailsResponse when saving GameDetails (**)
- URL image when saving image

** the GameDetailsResponse implementation was harder than it looked. Looks like Spring Data JPA doesn't automatically refresh the objects in memory when one entity is saved. Instead, it waits for the method to finish. Having that in count, I've had to manually add the entities in memory to be able to return the GameDetailsResponse in the same method where the GameDetails was saved.