### PR TITLE
feat: pagination

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
@@ -17,8 +17,8 @@ import java.util.UUID
 
 @RestController
 class UserController(private val userService: IUserService) : IUserController {
-    override fun getUserPlayers(userId: UUID): List<PlayerResponse> =
-        userService.getUserPlayers(userId)
+    override fun getUserPlayers(userId: UUID, pageNumber: Int, pageSize: Int): Page<PlayerResponse> =
+        userService.getUserPlayers(userId, pageNumber, pageSize)
 
     override fun getUserGames(
         @PathVariable userId: UUID,

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
@@ -32,8 +32,8 @@ class UserController(private val userService: IUserService) : IUserController {
     override fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse> =
         userService.getUserFields(userId, pageNumber, pageSize)
 
-    override fun getUserSeasons(userId: UUID): List<SeasonResponse> =
-        userService.getUserSeasons(userId)
+    override fun getUserSeasons(userId: UUID, pageNumber: Int, pageSize: Int): Page<SeasonResponse> =
+        userService.getUserSeasons(userId, pageNumber, pageSize)
 
     override fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse =
         userService.updateUser(userId, updateUserRequest)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
@@ -9,8 +9,6 @@ import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.services.interfaces.IUserService
 import org.springframework.data.domain.Page
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 import java.util.UUID
@@ -21,13 +19,15 @@ class UserController(private val userService: IUserService) : IUserController {
         userService.getUserPlayers(userId, pageNumber, pageSize)
 
     override fun getUserGames(
-        @PathVariable userId: UUID,
-        @RequestParam dateFrom: LocalDate?,
-        @RequestParam dateTo: LocalDate?,
-        @RequestParam fieldId: UUID?,
-        @RequestParam seasonId: UUID?
-    ): List<GameResponse> =
-        userService.getUserGames(userId, dateFrom, dateTo, fieldId, seasonId)
+        userId: UUID,
+        dateFrom: LocalDate?,
+        dateTo: LocalDate?,
+        fieldId: UUID?,
+        seasonId: UUID?,
+        pageNumber: Int,
+        pageSize: Int
+    ): Page<GameResponse> =
+        userService.getUserGames(userId, dateFrom, dateTo, fieldId, seasonId, pageNumber, pageSize)
 
     override fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse> =
         userService.getUserFields(userId, pageNumber, pageSize)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/UserController.kt
@@ -8,6 +8,7 @@ import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.services.interfaces.IUserService
+import org.springframework.data.domain.Page
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,8 +29,8 @@ class UserController(private val userService: IUserService) : IUserController {
     ): List<GameResponse> =
         userService.getUserGames(userId, dateFrom, dateTo, fieldId, seasonId)
 
-    override fun getUserFields(userId: UUID): List<FieldResponse> =
-        userService.getUserFields(userId)
+    override fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse> =
+        userService.getUserFields(userId, pageNumber, pageSize)
 
     override fun getUserSeasons(userId: UUID): List<SeasonResponse> =
         userService.getUserSeasons(userId)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
@@ -44,8 +44,10 @@ interface IUserController {
         @RequestParam dateFrom: LocalDate?,
         @RequestParam dateTo: LocalDate?,
         @RequestParam fieldId: UUID?,
-        @RequestParam seasonId: UUID?
-    ): List<GameResponse>
+        @RequestParam seasonId: UUID?,
+        @RequestParam(defaultValue = "0") pageNumber: Int,
+        @RequestParam(defaultValue = "10") pageSize: Int
+    ): Page<GameResponse>
 
     @GetMapping("/{userId}/fields")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
@@ -30,7 +30,11 @@ interface IUserController {
     @GetMapping("/{userId}/players")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Fetches a registered user players")
-    fun getUserPlayers(@PathVariable userId: UUID): List<PlayerResponse>
+    fun getUserPlayers(
+        @PathVariable userId: UUID,
+        @RequestParam(defaultValue = "0") pageNumber: Int,
+        @RequestParam(defaultValue = "10") pageSize: Int
+    ): Page<PlayerResponse>
 
     @GetMapping("/{userId}/games")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
@@ -8,6 +8,7 @@ import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -45,7 +46,11 @@ interface IUserController {
     @GetMapping("/{userId}/fields")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Fetches a registered user fields")
-    fun getUserFields(@PathVariable userId: UUID): List<FieldResponse>
+    fun getUserFields(
+        @PathVariable userId: UUID,
+        @RequestParam(defaultValue = "0") pageNumber: Int,
+        @RequestParam(defaultValue = "10") pageSize: Int
+    ): Page<FieldResponse>
 
     @GetMapping("/{userId}/seasons")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/interfaces/IUserController.kt
@@ -59,7 +59,11 @@ interface IUserController {
     @GetMapping("/{userId}/seasons")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "Fetches a registered user seasons")
-    fun getUserSeasons(@PathVariable userId: UUID): List<SeasonResponse>
+    fun getUserSeasons(
+        @PathVariable userId: UUID,
+        @RequestParam(defaultValue = "0") pageNumber: Int,
+        @RequestParam(defaultValue = "10") pageSize: Int
+    ): Page<SeasonResponse>
 
     @PatchMapping("/{userId}")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Field.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Field.kt
@@ -4,6 +4,7 @@ import com.esosa.f5pi_backend.controllers.responses.FieldResponse
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -12,6 +13,8 @@ data class Field(
 
     @ManyToOne
     val user: User,
+
+    val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @Id
     val id: UUID = UUID.randomUUID()

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Player.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Player.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -16,6 +17,8 @@ data class Player(
     val user: User,
 
     var imageURL: String,
+
+    val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @OneToMany(mappedBy = "player", cascade = [CascadeType.ALL])
     val memberOf: List<Member> = emptyList(),

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/Season.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/Season.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -16,6 +17,8 @@ data class Season(
 
     @ManyToOne
     val user: User,
+
+    val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @OneToMany(mappedBy = "season")
     val games: List<Game> = emptyList(),

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IFieldRepository.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IFieldRepository.kt
@@ -1,7 +1,12 @@
 package com.esosa.f5pi_backend.data.repositories
 
 import com.esosa.f5pi_backend.data.models.Field
+import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface IFieldRepository : JpaRepository<Field, UUID>
+interface IFieldRepository : JpaRepository<Field, UUID> {
+    fun findByUser(pageRequest: PageRequest, user: User): Page<Field>
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IGameRepository.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IGameRepository.kt
@@ -4,6 +4,8 @@ import com.esosa.f5pi_backend.data.models.Field
 import com.esosa.f5pi_backend.data.models.Game
 import com.esosa.f5pi_backend.data.models.Season
 import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import java.time.LocalDate
@@ -18,10 +20,11 @@ interface IGameRepository: JpaRepository<Game, UUID> {
             "AND (?5 is null or g.season = ?5)"
     )
     fun findByUser(
+        pageRequest: PageRequest,
         user: User,
         dateFrom: LocalDate?,
         dateTo: LocalDate?,
         field: Field?,
         season: Season?
-    ): List<Game>
+    ): Page<Game>
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IPlayerRepository.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/IPlayerRepository.kt
@@ -4,6 +4,9 @@ import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
 import com.esosa.f5pi_backend.data.models.Field
 import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.models.Season
+import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import java.util.UUID
@@ -27,4 +30,5 @@ interface IPlayerRepository: JpaRepository<Player, UUID> {
             + "AND (?2 is null OR g.field = ?2) "
             + "AND (?3 is null OR g.season = ?3)")
     fun getPlayerStatistics(player: Player, field: Field?, season: Season?): PlayerStatisticsResponse
+    fun findByUser(pageRequest: PageRequest, user: User): Page<Player>
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/ISeasonRepository.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/repositories/ISeasonRepository.kt
@@ -1,7 +1,12 @@
 package com.esosa.f5pi_backend.data.repositories
 
 import com.esosa.f5pi_backend.data.models.Season
+import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface ISeasonRepository : JpaRepository<Season, UUID>
+interface ISeasonRepository : JpaRepository<Season, UUID> {
+    fun findByUser(pageRequest: PageRequest, user: User): Page<Season>
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FieldService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FieldService.kt
@@ -8,6 +8,8 @@ import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.data.repositories.IFieldRepository
 import com.esosa.f5pi_backend.services.interfaces.IFieldService
 import com.esosa.f5pi_backend.services.interfaces.IUserService
+import com.esosa.f5pi_backend.utils.PageMapper
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -41,6 +43,10 @@ class FieldService(
     override fun findFieldByIdOrThrowException(fieldId: UUID): Field =
         fieldRepository.findById(fieldId)
             .orElseThrow { ResponseStatusException(HttpStatus.BAD_REQUEST, "Field with id $fieldId does not exist") }
+
+    override fun getUserFields(user: User, pageNumber: Int, pageSize: Int): Page<FieldResponse> =
+        fieldRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize), user )
+            .map(Field::buildFieldResponse)
 
     private fun ifFieldDoesNotExistThrowException(fieldId: UUID) {
         if (!fieldRepository.existsById(fieldId))

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FieldService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/FieldService.kt
@@ -45,7 +45,7 @@ class FieldService(
             .orElseThrow { ResponseStatusException(HttpStatus.BAD_REQUEST, "Field with id $fieldId does not exist") }
 
     override fun getUserFields(user: User, pageNumber: Int, pageSize: Int): Page<FieldResponse> =
-        fieldRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize), user )
+        fieldRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize, "createdAt"), user )
             .map(Field::buildFieldResponse)
 
     private fun ifFieldDoesNotExistThrowException(fieldId: UUID) {

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/GameService.kt
@@ -17,6 +17,8 @@ import com.esosa.f5pi_backend.services.interfaces.IGameService
 import com.esosa.f5pi_backend.services.interfaces.ISeasonService
 import com.esosa.f5pi_backend.services.interfaces.ITeamService
 import com.esosa.f5pi_backend.services.interfaces.IUserService
+import com.esosa.f5pi_backend.utils.PageMapper
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -85,10 +87,18 @@ class GameService(
         dateFrom: LocalDate?,
         dateTo: LocalDate?,
         field: Field?,
-        season: Season?
-    ): List<GameResponse> =
-        gameRepository.findByUser(user, dateFrom, dateTo, field, season)
-            .map(Game::buildGameResponse)
+        season: Season?,
+        pageNumber: Int,
+        pageSize: Int
+    ): Page<GameResponse> =
+        gameRepository.findByUser(
+            PageMapper.buildPageRequest(pageNumber, pageSize, "date"),
+            user,
+            dateFrom,
+            dateTo,
+            field,
+            season
+        ).map(Game::buildGameResponse)
 
     private fun calculateTeamGoals(teams: List<TeamRequest>): Pair<Int, Int> {
         val team1Goals = teams[0].members.sumOf { it.goalsScored } + teams[1].members.sumOf { it.ownGoals }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
@@ -71,7 +71,7 @@ class PlayerService(
             .orElseThrow { ResponseStatusException(HttpStatus.BAD_REQUEST, "Player with id $playerId does not exist") }
 
     override fun getUserPlayers(user: User, pageNumber: Int, pageSize: Int): Page<PlayerResponse> =
-        playerRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize), user )
+        playerRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize, "createdAt"), user )
             .map(Player::buildPlayerResponse)
 
     private fun uploadPlayerImage(multiPartFile: MultipartFile): String =

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/PlayerService.kt
@@ -9,7 +9,9 @@ import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.repositories.IPlayerRepository
 import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.services.interfaces.*
+import com.esosa.f5pi_backend.utils.PageMapper
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -67,6 +69,10 @@ class PlayerService(
     override fun findPlayerByIdOrThrowException(playerId: UUID): Player =
         playerRepository.findById(playerId)
             .orElseThrow { ResponseStatusException(HttpStatus.BAD_REQUEST, "Player with id $playerId does not exist") }
+
+    override fun getUserPlayers(user: User, pageNumber: Int, pageSize: Int): Page<PlayerResponse> =
+        playerRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize), user )
+            .map(Player::buildPlayerResponse)
 
     private fun uploadPlayerImage(multiPartFile: MultipartFile): String =
         fileUploadService.uploadFile(multiPartFile)

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/SeasonService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/SeasonService.kt
@@ -8,6 +8,8 @@ import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.data.repositories.ISeasonRepository
 import com.esosa.f5pi_backend.services.interfaces.ISeasonService
 import com.esosa.f5pi_backend.services.interfaces.IUserService
+import com.esosa.f5pi_backend.utils.PageMapper
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -43,6 +45,10 @@ class SeasonService(
     override fun findSeasonByIdOrThrowException(seasonId: UUID): Season =
         seasonRepository.findById(seasonId)
             .orElseThrow { ResponseStatusException(HttpStatus.BAD_REQUEST, "Season with id $seasonId does not exist") }
+
+    override fun getUserSeasons(user: User, pageNumber: Int, pageSize: Int): Page<SeasonResponse> =
+        seasonRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize), user )
+            .map(Season::buildSeasonResponse)
 
     private fun ifSeasonDoesNotExistThrowException(seasonId: UUID) {
         if (!seasonRepository.existsById(seasonId))

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/SeasonService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/SeasonService.kt
@@ -47,7 +47,7 @@ class SeasonService(
             .orElseThrow { ResponseStatusException(HttpStatus.BAD_REQUEST, "Season with id $seasonId does not exist") }
 
     override fun getUserSeasons(user: User, pageNumber: Int, pageSize: Int): Page<SeasonResponse> =
-        seasonRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize), user )
+        seasonRepository.findByUser( PageMapper.buildPageRequest(pageNumber, pageSize, "createdAt"), user )
             .map(Season::buildSeasonResponse)
 
     private fun ifSeasonDoesNotExistThrowException(seasonId: UUID) {

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
@@ -6,7 +6,6 @@ import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
-import com.esosa.f5pi_backend.data.models.Season
 import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.data.repositories.IUserRepository
 import com.esosa.f5pi_backend.services.interfaces.*
@@ -70,10 +69,12 @@ class UserService(
             pageSize
         )
 
-    override fun getUserSeasons(userId: UUID): List<SeasonResponse> =
-        findUserByIdOrThrowException(userId)
-            .seasons
-            .map(Season::buildSeasonResponse)
+    override fun getUserSeasons(userId: UUID, pageNumber: Int, pageSize: Int): Page<SeasonResponse> =
+        seasonService.getUserSeasons(
+            findUserByIdOrThrowException(userId),
+            pageNumber,
+            pageSize
+        )
 
     override fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse =
         findUserByIdOrThrowException(userId).let { user ->

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
@@ -6,7 +6,6 @@ import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
-import com.esosa.f5pi_backend.data.models.Field
 import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.models.Season
 import com.esosa.f5pi_backend.data.models.User
@@ -16,6 +15,7 @@ import com.esosa.f5pi_backend.services.interfaces.IGameService
 import com.esosa.f5pi_backend.services.interfaces.ISeasonService
 import com.esosa.f5pi_backend.services.interfaces.IUserService
 import org.springframework.context.annotation.Lazy
+import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
@@ -64,10 +64,12 @@ class UserService(
             gameService.getGamesByUser(user, dateFrom, dateTo, field, season)
         }
 
-    override fun getUserFields(userId: UUID): List<FieldResponse> =
-        findUserByIdOrThrowException(userId)
-            .fields
-            .map(Field::buildFieldResponse)
+    override fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse> =
+        fieldService.getUserFields(
+            findUserByIdOrThrowException(userId),
+            pageNumber,
+            pageSize
+        )
 
     override fun getUserSeasons(userId: UUID): List<SeasonResponse> =
         findUserByIdOrThrowException(userId)

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
@@ -6,14 +6,10 @@ import com.esosa.f5pi_backend.controllers.responses.GameResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
-import com.esosa.f5pi_backend.data.models.Player
 import com.esosa.f5pi_backend.data.models.Season
 import com.esosa.f5pi_backend.data.models.User
 import com.esosa.f5pi_backend.data.repositories.IUserRepository
-import com.esosa.f5pi_backend.services.interfaces.IFieldService
-import com.esosa.f5pi_backend.services.interfaces.IGameService
-import com.esosa.f5pi_backend.services.interfaces.ISeasonService
-import com.esosa.f5pi_backend.services.interfaces.IUserService
+import com.esosa.f5pi_backend.services.interfaces.*
 import org.springframework.context.annotation.Lazy
 import org.springframework.data.domain.Page
 import org.springframework.http.HttpStatus
@@ -27,7 +23,8 @@ class UserService(
     private val userRepository: IUserRepository,
     @Lazy private val gameService: IGameService,
     @Lazy private val fieldService: IFieldService,
-    @Lazy private val seasonService: ISeasonService
+    @Lazy private val seasonService: ISeasonService,
+    @Lazy private val playerService: IPlayerService
 ) : IUserService {
 
     override fun saveUser(user: User): User =
@@ -46,10 +43,12 @@ class UserService(
         userRepository.findById(userId)
             .orElseThrow{ ResponseStatusException(HttpStatus.BAD_REQUEST, "Username with id $userId does not exist") }
 
-    override fun getUserPlayers(userId: UUID): List<PlayerResponse> =
-        findUserByIdOrThrowException(userId)
-            .players
-            .map(Player::buildPlayerResponse)
+    override fun getUserPlayers(userId: UUID, pageNumber: Int, pageSize: Int): Page<PlayerResponse> =
+        playerService.getUserPlayers(
+            findUserByIdOrThrowException(userId),
+            pageNumber,
+            pageSize
+        )
 
     override fun getUserGames(
         userId: UUID,

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
@@ -54,12 +54,14 @@ class UserService(
         dateFrom: LocalDate?,
         dateTo: LocalDate?,
         fieldId: UUID?,
-        seasonId: UUID?
-    ): List<GameResponse> =
+        seasonId: UUID?,
+        pageNumber: Int,
+        pageSize: Int
+    ): Page<GameResponse> =
         findUserByIdOrThrowException(userId).let { user ->
             val field = fieldId?.let { fieldService.findFieldByIdOrThrowException(it) }
             val season = seasonId?.let { seasonService.findSeasonByIdOrThrowException(it) }
-            gameService.getGamesByUser(user, dateFrom, dateTo, field, season)
+            gameService.getGamesByUser(user, dateFrom, dateTo, field, season, pageNumber, pageSize)
         }
 
     override fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse> =

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IFieldService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IFieldService.kt
@@ -4,6 +4,8 @@ import com.esosa.f5pi_backend.controllers.requests.CreateFieldRequest
 import com.esosa.f5pi_backend.controllers.requests.UpdateFieldRequest
 import com.esosa.f5pi_backend.controllers.responses.FieldResponse
 import com.esosa.f5pi_backend.data.models.Field
+import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
 import java.util.UUID
 
 interface IFieldService {
@@ -11,4 +13,5 @@ interface IFieldService {
     fun updateField(fieldId: UUID, updateFieldRequest: UpdateFieldRequest): FieldResponse
     fun deleteField(fieldId: UUID)
     fun findFieldByIdOrThrowException(fieldId: UUID): Field
+    fun getUserFields(user: User, pageNumber: Int, pageSize: Int): Page<FieldResponse>
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IGameService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IGameService.kt
@@ -9,6 +9,7 @@ import com.esosa.f5pi_backend.data.models.Field
 import com.esosa.f5pi_backend.data.models.Game
 import com.esosa.f5pi_backend.data.models.Season
 import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
 import java.time.LocalDate
 import java.util.UUID
 
@@ -24,6 +25,8 @@ interface IGameService {
         dateFrom: LocalDate? = null,
         dateTo: LocalDate? = null,
         field: Field? = null,
-        season: Season? = null
-    ): List<GameResponse>
+        season: Season? = null,
+        pageNumber: Int,
+        pageSize: Int
+    ): Page<GameResponse>
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IPlayerService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IPlayerService.kt
@@ -6,6 +6,8 @@ import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.PlayerStatisticsResponse
 import com.esosa.f5pi_backend.controllers.responses.SavePlayerImageResponse
 import com.esosa.f5pi_backend.data.models.Player
+import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
 import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
@@ -20,4 +22,5 @@ interface IPlayerService {
     fun updatePlayer(playerId: UUID, updatePlayerRequest: UpdatePlayerRequest): PlayerResponse
     fun deletePlayer(playerId: UUID)
     fun findPlayerByIdOrThrowException(playerId: UUID): Player
+    fun getUserPlayers(user: User, pageNumber: Int, pageSize: Int): Page<PlayerResponse>
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/ISeasonService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/ISeasonService.kt
@@ -4,6 +4,8 @@ import com.esosa.f5pi_backend.controllers.requests.CreateSeasonRequest
 import com.esosa.f5pi_backend.controllers.requests.UpdateSeasonRequest
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.data.models.Season
+import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
 import java.util.UUID
 
 interface ISeasonService {
@@ -11,4 +13,5 @@ interface ISeasonService {
     fun updateSeason(seasonId: UUID, updateSeasonRequest: UpdateSeasonRequest): SeasonResponse
     fun deleteSeason(seasonId: UUID)
     fun findSeasonByIdOrThrowException(seasonId: UUID): Season
+    fun getUserSeasons(user: User, pageNumber: Int, pageSize: Int): Page<SeasonResponse>
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
@@ -16,7 +16,7 @@ interface IUserService {
     fun ifExistsUsernameThrowException(username: String)
     fun findUserByUsernameOrThrowException(username: String): User
     fun findUserByIdOrThrowException(userId: UUID): User
-    fun getUserPlayers(userId: UUID): List<PlayerResponse>
+    fun getUserPlayers(userId: UUID, pageNumber: Int, pageSize: Int): Page<PlayerResponse>
     fun getUserGames(
         userId: UUID,
         dateFrom: LocalDate?,

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
@@ -7,6 +7,7 @@ import com.esosa.f5pi_backend.controllers.responses.PlayerResponse
 import com.esosa.f5pi_backend.controllers.responses.SeasonResponse
 import com.esosa.f5pi_backend.controllers.responses.UserResponse
 import com.esosa.f5pi_backend.data.models.User
+import org.springframework.data.domain.Page
 import java.time.LocalDate
 import java.util.UUID
 
@@ -23,7 +24,7 @@ interface IUserService {
         fieldId: UUID?,
         seasonId: UUID?
     ): List<GameResponse>
-    fun getUserFields(userId: UUID): List<FieldResponse>
+    fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse>
     fun getUserSeasons(userId: UUID): List<SeasonResponse>
     fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse
     fun deleteUser(userId: UUID)

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
@@ -22,8 +22,10 @@ interface IUserService {
         dateFrom: LocalDate?,
         dateTo: LocalDate?,
         fieldId: UUID?,
-        seasonId: UUID?
-    ): List<GameResponse>
+        seasonId: UUID?,
+        pageNumber: Int,
+        pageSize: Int
+    ): Page<GameResponse>
     fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse>
     fun getUserSeasons(userId: UUID, pageNumber: Int, pageSize: Int): Page<SeasonResponse>
     fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/interfaces/IUserService.kt
@@ -25,7 +25,7 @@ interface IUserService {
         seasonId: UUID?
     ): List<GameResponse>
     fun getUserFields(userId: UUID, pageNumber: Int, pageSize: Int): Page<FieldResponse>
-    fun getUserSeasons(userId: UUID): List<SeasonResponse>
+    fun getUserSeasons(userId: UUID, pageNumber: Int, pageSize: Int): Page<SeasonResponse>
     fun updateUser(userId: UUID, updateUserRequest: UpdateUserRequest): UserResponse
     fun deleteUser(userId: UUID)
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/utils/PageMapper.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/utils/PageMapper.kt
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Sort
 
 class PageMapper {
     companion object {
-        fun buildPageRequest(pageNumber: Int, pageSize: Int) =
-            PageRequest.of(pageNumber, pageSize, Sort.by("createdAt"))
+        fun buildPageRequest(pageNumber: Int, pageSize: Int, sortingAttribute: String) =
+            PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, sortingAttribute))
     }
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/utils/PageMapper.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/utils/PageMapper.kt
@@ -1,0 +1,11 @@
+package com.esosa.f5pi_backend.utils
+
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+
+class PageMapper {
+    companion object {
+        fun buildPageRequest(pageNumber: Int, pageSize: Int) =
+            PageRequest.of(pageNumber, pageSize, Sort.by("createdAt"))
+    }
+}


### PR DESCRIPTION
Added pagination to optimize database queries and to get a better handling of the data-displaying in the front-end. Now the content is returned **sorted by their creation date**, so an attribute was added to the Field, Season and Player entities. 
Games are sorted by their previously registered date.