### PR TITLE
feat: integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
 	runtimeOnly("com.mysql:mysql-connector-j")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
+	runtimeOnly("com.h2database:h2")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/data/models/User.kt
@@ -6,9 +6,11 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
 import java.util.UUID
 
 @Entity
+@Table(name = "app_user")
 data class User(
     val username: String,
     val password: String,

--- a/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/services/implementations/UserService.kt
@@ -36,11 +36,11 @@ class UserService(
 
     override fun findUserByUsernameOrThrowException(username: String): User =
         userRepository.findByUsername(username)
-            ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Username does not exist")
+            ?: throw ResponseStatusException(HttpStatus.BAD_REQUEST, "User with username $username does not exist")
 
     override fun findUserByIdOrThrowException(userId: UUID): User =
         userRepository.findById(userId)
-            .orElseThrow{ ResponseStatusException(HttpStatus.BAD_REQUEST, "Username with id $userId does not exist") }
+            .orElseThrow{ ResponseStatusException(HttpStatus.BAD_REQUEST, "User with id $userId does not exist") }
 
     override fun getUserPlayers(
         userId: UUID,

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/base/BaseIntegrationTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/base/BaseIntegrationTest.kt
@@ -1,0 +1,25 @@
+package com.esosa.f5pi_backend.controllers.base
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.web.servlet.MockMvc
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+open class BaseIntegrationTest {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    protected fun <T> toJson(value: T): String =
+        objectMapper.writeValueAsString(value)
+}

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/FieldControllerTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/FieldControllerTest.kt
@@ -1,0 +1,62 @@
+package com.esosa.f5pi_backend.controllers.implementations
+
+import com.esosa.f5pi_backend.controllers.base.BaseIntegrationTest
+import com.esosa.f5pi_backend.controllers.requests.CreateFieldRequest
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+class FieldControllerTest : BaseIntegrationTest() {
+
+    @Test
+    fun `should return bad request when user does not exist`() {
+        val userId = UUID.randomUUID()
+        val fieldRequest = CreateFieldRequest("Test Field", userId)
+        val jsonRequest = toJson(fieldRequest)
+
+        mockMvc.perform(
+            post("/api/v1/fields")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonRequest)
+        ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("User with id $userId does not exist"))
+    }
+
+    @Test
+    @Sql("/scripts/fields/insert_fields.sql")
+    fun `should return bad request when field already exist`() {
+        val userId = UUID.fromString("58fae25b-ea38-4e7b-ab2d-9f555a67836b")
+        val fieldRequest = CreateFieldRequest("Field Test", userId)
+        val jsonRequest = toJson(fieldRequest)
+
+        mockMvc.perform(
+            post("/api/v1/fields")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonRequest)
+        ).andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.message").value("Field name ${fieldRequest.name} already exists for the user"))
+    }
+
+    @Test
+    @Sql("/scripts/fields/insert_fields.sql")
+    fun `should return created when field is created`() {
+        val userId = UUID.fromString("58fae25b-ea38-4e7b-ab2d-9f555a67836b")
+        val fieldRequest = CreateFieldRequest("Field Test 2", userId)
+        val jsonRequest = toJson(fieldRequest)
+
+        mockMvc.perform(
+            post("/api/v1/fields")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(jsonRequest)
+        ).andExpect(status().isCreated)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.fieldName").value(fieldRequest.name))
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test_db
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+
+cors:
+  originPatterns: ${CORS_ORIGINS:http://localhost:4200}
+
+jwt:
+  key: ${MOCKED_JWT_KEY:SgHeAYlgQ+JozW6vY7xxsPQXuvvqSDL+6PiBkpr1KvA=}
+  access-token-expiration: 3600000
+  refresh-token-expiration: 432000000
+
+springdoc:
+  swagger-ui:
+    disable-swagger-default-url: true
+    path: /
+
+ai:
+  url: http://127.0.0.1:5000
+  message: MOCKED_AI_MESSAGE
+
+cloudinary:
+  cloud-name: MOCKED_CLOUDINARY_NAME
+  api-key: MOCKED_API_KEY
+  api-secret: MOCKED_API_SECRET
+  default-image-url: MOCKED_IMAGE_URL

--- a/src/test/resources/scripts/fields/insert_fields.sql
+++ b/src/test/resources/scripts/fields/insert_fields.sql
@@ -1,0 +1,5 @@
+INSERT INTO app_user (id, username, password, email)
+VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836b', 'esosa', '123456', 'esosa@gmail.com');
+
+INSERT INTO field (id, name, user_id)
+VALUES ('58fae25b-ea38-4e7b-ab2d-9f555a67836c', 'Field Test', '58fae25b-ea38-4e7b-ab2d-9f555a67836b');


### PR DESCRIPTION
Se implementaron un par de tests de integración relacionados al guardado de un Field.

## Funcionamiento

Todos los tests de integración extienden de la clase **BaseIntegrationTest**. Dicha clase contiene las anotaciones y la configuración necesarias para: 

1. Cargar todos los beans de SpringBoot dentro del contenedor de beans.
2. Utilizar una base de datos en memoria ([h2](https://www.h2database.com/html/main.html)) para los tests.
3. Inicializar los objetos [MockMvc](https://docs.spring.io/spring-framework/reference/6.0/testing/spring-mvc-test-framework.html) y [ObjectMapper](https://www.baeldung.com/jackson-custom-serialization) para simular las peticiones HTTP a los controladores.

Para los demás tests de integración, es recomendable seguir una estructura similar a los tests presentados en esta MR.