### PR TITLE
Feat/sql injection tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,10 +45,12 @@ dependencies {
 	testImplementation("org.mockito:mockito-core:5.11.0")
 	testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 	testImplementation("org.mockito:mockito-junit-jupiter:5.11.0")
+	testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
 
 
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.3")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
@@ -3,6 +3,7 @@ package com.esosa.f5pi_backend.controllers.implementations
 import com.esosa.f5pi_backend.controllers.base.BaseIntegrationTest
 import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.LoginRequest
+import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.RegisterRequest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -78,6 +79,34 @@ class AuthControllerTest : BaseIntegrationTest() {
                 post("/auth/check-token")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(toJson(CheckTokenRequest("DELETE FROM USER WHERE 1 = 1")))
+            ).andExpect(status().isUnauthorized)
+        }
+    }
+
+    @Test
+    fun `should not refresh token with SQL injection payload`() {
+        RegisterRequest(
+            "DELETE FROM USER WHERE 1 = 1",
+            "DELETE FROM GAME WHERE 1 = 2",
+            "DELETE FROM FIELD WHERE 1 = 1",
+            "test@gmail.com"
+        ).also {
+            mockMvc.perform(
+                post("/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(it))
+            ).andExpect(status().isCreated)
+        }.also {
+            mockMvc.perform(
+                post("/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(LoginRequest(it.username, it.password)))
+            ).andExpect(status().isOk)
+        }.also {
+            mockMvc.perform(
+                post("/auth/refresh")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(RefreshTokenRequest("DELETE FROM USER WHERE 1 = 1")))
             ).andExpect(status().isUnauthorized)
         }
     }

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
@@ -56,7 +56,7 @@ class AuthControllerTest : BaseIntegrationTest() {
     }
 
     @Test
-    fun `should check token with SQL injection payload`() {
+    fun `should not check token with SQL injection payload`() {
         RegisterRequest(
             "DELETE FROM USER WHERE 1 = 1",
             "DELETE FROM GAME WHERE 1 = 2",

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
@@ -1,6 +1,7 @@
 package com.esosa.f5pi_backend.controllers.implementations
 
 import com.esosa.f5pi_backend.controllers.base.BaseIntegrationTest
+import com.esosa.f5pi_backend.controllers.requests.CheckTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.LoginRequest
 import com.esosa.f5pi_backend.controllers.requests.RegisterRequest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -51,5 +52,33 @@ class AuthControllerTest : BaseIntegrationTest() {
         )
 
         assertEquals(userCountBefore?.plus(1), userCountAfter)
+    }
+
+    @Test
+    fun `should check token with SQL injection payload`() {
+        RegisterRequest(
+            "DELETE FROM USER WHERE 1 = 1",
+            "DELETE FROM GAME WHERE 1 = 2",
+            "DELETE FROM FIELD WHERE 1 = 1",
+            "test@gmail.com"
+        ).also {
+            mockMvc.perform(
+                post("/auth/register")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(it))
+            ).andExpect(status().isCreated)
+        }.also {
+            mockMvc.perform(
+                post("/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(LoginRequest(it.username, it.password)))
+            ).andExpect(status().isOk)
+        }.also {
+            mockMvc.perform(
+                post("/auth/check-token")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(CheckTokenRequest("DELETE FROM USER WHERE 1 = 1")))
+            ).andExpect(status().isUnauthorized)
+        }
     }
 }

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
@@ -7,14 +7,19 @@ import com.esosa.f5pi_backend.controllers.requests.RefreshTokenRequest
 import com.esosa.f5pi_backend.controllers.requests.RegisterRequest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.stream.Stream
 
 const val SQL_INJECTION_USERNAME = "DELETE FROM USER WHERE 1 = 1"
+
 class AuthControllerTest : BaseIntegrationTest() {
 
     @Autowired
@@ -55,8 +60,14 @@ class AuthControllerTest : BaseIntegrationTest() {
 
         assertEquals(userCountBefore?.plus(1), userCountAfter)
     }
-
-    fun registerAndLogin(password: String, fullName: String, email: String){
+    companion object {
+        @JvmStatic
+        private fun endpointAndRequestProvider(): Stream<Arguments> = Stream.of(
+            Arguments.of("/auth/check-token", CheckTokenRequest(SQL_INJECTION_USERNAME)),
+            Arguments.of("/auth/refresh", RefreshTokenRequest(SQL_INJECTION_USERNAME)),
+        )
+    }
+    private fun registerAndLogin(password: String, fullName: String, email: String) {
         RegisterRequest(
             SQL_INJECTION_USERNAME,
             password,
@@ -77,31 +88,18 @@ class AuthControllerTest : BaseIntegrationTest() {
         }
     }
 
-    @Test
-    fun `should not check token with SQL injection payload`() {
+    @ParameterizedTest
+    @MethodSource("endpointAndRequestProvider")
+    fun `should not allow SQL Injection payloads for checkToken `(endpoint:String , requestBody: Any){
         registerAndLogin(
-            "DELETE FROM GAME WHERE 1 = 2",
+            "DELETE FROM GAME WHERE 1 = 1",
             "DELETE FROM FIELD WHERE 1 = 1",
             "test@gmail.com"
         )
         mockMvc.perform(
-            post("/auth/check-token")
+            post(endpoint)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(CheckTokenRequest(SQL_INJECTION_USERNAME)))
-        ).andExpect(status().isUnauthorized)
-    }
-
-    @Test
-    fun `should not refresh token with SQL injection payload`() {
-        registerAndLogin(
-            "DELETE FROM GAME WHERE 1 = 2",
-            "DELETE FROM FIELD WHERE 1 = 1",
-            "test@gmail.com"
-        )
-        mockMvc.perform(
-            post("/auth/refresh")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(RefreshTokenRequest(SQL_INJECTION_USERNAME)))
+                .content(toJson(requestBody))
         ).andExpect(status().isUnauthorized)
     }
 

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/implementations/AuthControllerTest.kt
@@ -14,6 +14,7 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
+const val SQL_INJECTION_USERNAME = "DELETE FROM USER WHERE 1 = 1"
 class AuthControllerTest : BaseIntegrationTest() {
 
     @Autowired
@@ -55,13 +56,12 @@ class AuthControllerTest : BaseIntegrationTest() {
         assertEquals(userCountBefore?.plus(1), userCountAfter)
     }
 
-    @Test
-    fun `should not check token with SQL injection payload`() {
+    fun registerAndLogin(password: String, fullName: String, email: String){
         RegisterRequest(
-            "DELETE FROM USER WHERE 1 = 1",
-            "DELETE FROM GAME WHERE 1 = 2",
-            "DELETE FROM FIELD WHERE 1 = 1",
-            "test@gmail.com"
+            SQL_INJECTION_USERNAME,
+            password,
+            fullName,
+            email,
         ).also {
             mockMvc.perform(
                 post("/auth/register")
@@ -74,40 +74,35 @@ class AuthControllerTest : BaseIntegrationTest() {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(toJson(LoginRequest(it.username, it.password)))
             ).andExpect(status().isOk)
-        }.also {
-            mockMvc.perform(
-                post("/auth/check-token")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(toJson(CheckTokenRequest("DELETE FROM USER WHERE 1 = 1")))
-            ).andExpect(status().isUnauthorized)
         }
     }
 
     @Test
-    fun `should not refresh token with SQL injection payload`() {
-        RegisterRequest(
-            "DELETE FROM USER WHERE 1 = 1",
+    fun `should not check token with SQL injection payload`() {
+        registerAndLogin(
             "DELETE FROM GAME WHERE 1 = 2",
             "DELETE FROM FIELD WHERE 1 = 1",
             "test@gmail.com"
-        ).also {
-            mockMvc.perform(
-                post("/auth/register")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(toJson(it))
-            ).andExpect(status().isCreated)
-        }.also {
-            mockMvc.perform(
-                post("/auth/login")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(toJson(LoginRequest(it.username, it.password)))
-            ).andExpect(status().isOk)
-        }.also {
-            mockMvc.perform(
-                post("/auth/refresh")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(toJson(RefreshTokenRequest("DELETE FROM USER WHERE 1 = 1")))
-            ).andExpect(status().isUnauthorized)
-        }
+        )
+        mockMvc.perform(
+            post("/auth/check-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(CheckTokenRequest(SQL_INJECTION_USERNAME)))
+        ).andExpect(status().isUnauthorized)
     }
+
+    @Test
+    fun `should not refresh token with SQL injection payload`() {
+        registerAndLogin(
+            "DELETE FROM GAME WHERE 1 = 2",
+            "DELETE FROM FIELD WHERE 1 = 1",
+            "test@gmail.com"
+        )
+        mockMvc.perform(
+            post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(RefreshTokenRequest(SQL_INJECTION_USERNAME)))
+        ).andExpect(status().isUnauthorized)
+    }
+
 }


### PR DESCRIPTION
Siguiendo la línea de #23 agregué dos test de integración de SQL Injection para cumplir con pruebas de seguridad, donde se verifica que no se ejecute realmente la instrucción SQL en los casos de:

- Se reciba una petición http con método POST al path: "/auth/check-token" con un cuerpo que contiene un token malicioso y no pase.
- Se reciba una petición http con método POST al path: "/auth/refresh" con un cuerpo que contiene un token malicioso y no pase

