### PR TITLE
feat: auth entrypoint

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/config/AuthConfig.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/config/AuthConfig.kt
@@ -20,9 +20,9 @@ class AuthConfig {
 
     @Bean
     fun authenticationProvider(userRepository: IUserRepository): AuthenticationProvider =
-        DaoAuthenticationProvider().also { dao ->
-            dao.setUserDetailsService(userDetailsService(userRepository))
-            dao.setPasswordEncoder(passwordEncoder())
+        DaoAuthenticationProvider().apply {
+            setUserDetailsService(userDetailsService(userRepository))
+            setPasswordEncoder(passwordEncoder())
         }
 
     @Bean

--- a/src/main/kotlin/com/esosa/f5pi_backend/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/config/SecurityConfig.kt
@@ -1,7 +1,9 @@
 package com.esosa.f5pi_backend.config
 
+import com.esosa.f5pi_backend.security.entrypoint.JWTAuthEntryPoint
 import com.esosa.f5pi_backend.security.filter.JWTAuthenticationFilter
-import com.esosa.f5pi_backend.utils.WHITE_LIST_URL
+import com.esosa.f5pi_backend.utils.SWAGGER_URLS
+import com.esosa.f5pi_backend.utils.WHITE_LIST_URLS
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -9,30 +11,32 @@ import org.springframework.security.authentication.AuthenticationProvider
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
-import org.springframework.security.web.DefaultSecurityFilterChain
+import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
     private val authProvider: AuthenticationProvider,
+    private val entryPoint: JWTAuthEntryPoint,
 ) {
 
     @Bean
     fun securityFilterChain(
         http: HttpSecurity,
         jwtAuthenticationFilter: JWTAuthenticationFilter
-    ) : DefaultSecurityFilterChain =
+    ) : SecurityFilterChain =
         http
             .csrf { csrf -> csrf.disable() }
             .authorizeHttpRequests { httpRequests ->
                 httpRequests
-                    .requestMatchers(*WHITE_LIST_URL).permitAll()
+                    .requestMatchers(*WHITE_LIST_URLS, *SWAGGER_URLS).permitAll()
                     .requestMatchers(HttpMethod.GET, "api/v1/**").permitAll()
                     .anyRequest().authenticated()
             }
-            .sessionManagement { management -> management.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
-            .httpBasic { httpBasic -> httpBasic.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .httpBasic { it.disable() }
+            .exceptionHandling { it.authenticationEntryPoint(entryPoint) }
             .authenticationProvider(authProvider)
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/entrypoint/JWTAuthEntryPoint.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/entrypoint/JWTAuthEntryPoint.kt
@@ -1,0 +1,69 @@
+package com.esosa.f5pi_backend.security.entrypoint
+
+import com.esosa.f5pi_backend.exceptions.ExceptionPayload
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.CLAIMS_JWT_EXCEPTION_MESSAGE
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.EXPIRED_JWT_EXCEPTION_MESSAGE
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.JWT_EXCEPTION_DEFAULT_MESSAGE
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.MISSING_HEADER_EXCEPTION_MESSAGE
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.SIGNATURE_EXCEPTION_MESSAGE
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.USERNAME_NOT_FOUND_MESSAGE
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.jsonwebtoken.ClaimJwtException
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.security.SignatureException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+@Component
+class JWTAuthEntryPoint(private val objectMapper: ObjectMapper) : AuthenticationEntryPoint {
+
+    @Value("\${cors.originPatterns:default}")
+    private val corsOriginPatterns: String = ""
+
+    override fun commence(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authException: AuthenticationException?
+    ) {
+        buildExceptionPayload(authException?.cause ?: authException!!)
+            .also { configureResponse(response, it) }
+    }
+
+    private fun configureResponse(response: HttpServletResponse?, payload: ExceptionPayload) {
+        response?.apply {
+            contentType = APPLICATION_JSON_VALUE
+            status = payload.status
+            writer.write(objectMapper.writeValueAsString(payload))
+            setHeader("Access-Control-Allow-Origin", corsOriginPatterns)
+        }
+    }
+
+    private fun buildExceptionPayload(throwable: Throwable): ExceptionPayload =
+        buildExceptionMessage(throwable).let {
+            ExceptionPayload(
+                it.first,
+                it.second.value(),
+                LocalDateTime.now(),
+                throwable.stackTrace
+            )
+        }
+
+    private fun buildExceptionMessage(throwable: Throwable): Pair<String, HttpStatus> {
+        return when (throwable) {
+            is ExpiredJwtException -> EXPIRED_JWT_EXCEPTION_MESSAGE
+            is SignatureException -> SIGNATURE_EXCEPTION_MESSAGE
+            is ClaimJwtException -> CLAIMS_JWT_EXCEPTION_MESSAGE
+            is IllegalArgumentException -> MISSING_HEADER_EXCEPTION_MESSAGE
+            is UsernameNotFoundException -> USERNAME_NOT_FOUND_MESSAGE
+            else -> JWT_EXCEPTION_DEFAULT_MESSAGE
+        }
+    }
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/entrypoint/JWTAuthException.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/entrypoint/JWTAuthException.kt
@@ -1,0 +1,7 @@
+package com.esosa.f5pi_backend.security.entrypoint
+
+import org.springframework.security.core.AuthenticationException
+
+class JWTAuthException : AuthenticationException {
+    constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/filter/JWTAuthenticationFilter.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/filter/JWTAuthenticationFilter.kt
@@ -1,66 +1,80 @@
 package com.esosa.f5pi_backend.security.filter
 
+import com.esosa.f5pi_backend.security.entrypoint.JWTAuthEntryPoint
+import com.esosa.f5pi_backend.security.entrypoint.JWTAuthException
 import com.esosa.f5pi_backend.security.jwt.JWTService
 import com.esosa.f5pi_backend.security.service.CustomUserDetailsService
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.MISSING_HEADER_EXCEPTION_MESSAGE
+import com.esosa.f5pi_backend.utils.SWAGGER_URLS
+import com.esosa.f5pi_backend.utils.WHITE_LIST_URLS
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.http.HttpHeaders
+import org.apache.http.HttpHeaders.AUTHORIZATION
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource
 import org.springframework.stereotype.Component
 import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.OncePerRequestFilter
-import com.esosa.f5pi_backend.utils.WHITE_LIST_URL
 
 @Component
 class JWTAuthenticationFilter(
     private val userDetailsService: CustomUserDetailsService,
     private val jwtService: JWTService,
-    private val pathMatcher: AntPathMatcher
+    private val pathMatcher: AntPathMatcher,
+    private val entryPoint: JWTAuthEntryPoint
 ) : OncePerRequestFilter() {
-
-    private val ACCESS: String = "ACCESS"
 
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        val authHeader: String? = request.getHeader(HttpHeaders.AUTHORIZATION)
-
-        if (authHeader.isNullOrEmpty() || !authHeader.containsBearerToken()) {
+        runCatching {
+            authenticateRequest(request)
             filterChain.doFilter(request, response)
-            return
+        }.onFailure {
+            val authException = it as? AuthenticationException
+                ?: JWTAuthException("Authentication failed", it)
+            entryPoint.commence(request, response, authException)
         }
-
-        val token = authHeader.extractToken()
-        val username = jwtService.extractUsernameFromToken(token)
-
-        if (SecurityContextHolder.getContext().authentication == null) {
-            val user = userDetailsService.loadUserByUsername(username)
-
-            if (jwtService.isTokenValid(token, user) && jwtService.extractTokenTypeFromToken(token)!! == ACCESS)
-                updateContext(user, request)
-        }
-
-        filterChain.doFilter(request, response)
     }
 
     override fun shouldNotFilter(request: HttpServletRequest): Boolean =
-        WHITE_LIST_URL.any { url -> pathMatcher.match(url, request.requestURI) }
+        arrayOf(*WHITE_LIST_URLS, *SWAGGER_URLS).any { pathMatcher.match(it, request.requestURI) }
 
-    private fun updateContext(user: UserDetails, request: HttpServletRequest) {
-        val authToken = UsernamePasswordAuthenticationToken(user, null, user.authorities)
-        authToken.details = WebAuthenticationDetailsSource().buildDetails(request)
-        SecurityContextHolder.getContext().authentication = authToken
+    private fun authenticateRequest(request: HttpServletRequest) {
+        val authHeader = request.getValidAuthHeader()
+        val token = authHeader.extractToken()
+        val username = runCatchingAuthException { jwtService.extractUsernameFromToken(token) }
+        val user = runCatchingAuthException { userDetailsService.loadUserByUsername(username) }
+
+        if (jwtService.isTokenValid(token, user))
+            updateContext(user, request)
     }
 
-    private fun String?.containsBearerToken(): Boolean = this != null && startsWith("Bearer ")
+    private fun HttpServletRequest.getValidAuthHeader(): String =
+        getHeader(AUTHORIZATION)
+            ?.takeIf { it.startsWith("Bearer ") }
+            ?: throw JWTAuthException(
+                MISSING_HEADER_EXCEPTION_MESSAGE.first,
+                IllegalArgumentException("Authorization header is missing or invalid")
+            )
 
     private fun String.extractToken(): String =
-        substringAfter("Bearer ").takeIf { token -> token.isNotBlank() }
+        substringAfter("Bearer ").takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("Invalid JWT format")
+
+    private fun updateContext(user: UserDetails, request: HttpServletRequest) {
+        UsernamePasswordAuthenticationToken(user, null, user.authorities)
+            .apply { details = WebAuthenticationDetailsSource().buildDetails(request) }
+            .also { SecurityContextHolder.getContext().authentication = it }
+    }
+
+    private inline fun <T> runCatchingAuthException(block: () -> T): T =
+        runCatching { block() }
+            .getOrElse { throw JWTAuthException(it.localizedMessage, it) }
 }

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/jwt/JWTService.kt
@@ -5,7 +5,7 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.stereotype.Service
-import java.util.Date
+import java.util.*
 
 @Service
 class JWTService(jwtProperties: JWTProperties) {

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/utils/Constants.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/utils/Constants.kt
@@ -1,0 +1,15 @@
+package com.esosa.f5pi_backend.security.utils
+
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.UNAUTHORIZED
+
+class Constants {
+    companion object {
+        val EXPIRED_JWT_EXCEPTION_MESSAGE = "Session expired. Please log in again" to UNAUTHORIZED
+        val SIGNATURE_EXCEPTION_MESSAGE = "Invalid token. Please contact an administrator" to UNAUTHORIZED
+        val MISSING_HEADER_EXCEPTION_MESSAGE = "Missing authorization header" to UNAUTHORIZED
+        val CLAIMS_JWT_EXCEPTION_MESSAGE = "Token claims are invalid. Please contact an administrator" to FORBIDDEN
+        val JWT_EXCEPTION_DEFAULT_MESSAGE = "The JWT authentication failed. Please contact an administrator" to FORBIDDEN
+        val USERNAME_NOT_FOUND_MESSAGE = "Username not found. Please contact an administrator" to FORBIDDEN
+    }
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/utils/WhiteListURL.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/utils/WhiteListURL.kt
@@ -1,7 +1,10 @@
 package com.esosa.f5pi_backend.utils
 
-val WHITE_LIST_URL = arrayOf(
-    "/auth/**",
+val WHITE_LIST_URLS = arrayOf(
+    "/auth/*",
+)
+
+val SWAGGER_URLS = arrayOf(
     "/swagger-ui/**",
     "/v3/api-docs/**",
     "/",


### PR DESCRIPTION
## Explicación

Se agregó una implementación personalizada de un `AuthenticationEntrypoint`. Un Entrypoint es un objeto que se utiliza para manejar las excepciones que surjan desde los filtros de autenticación de Spring Security (en nuestro caso, un filtro personalizado para la autenticación vía JWT). 

A su vez, se realizaron refactorizaciones sobre la lógica del propio filtro y sobre la configuración de seguridad para lograr un código más extensible e idiomático.

Previamente, nuestra aplicación contaba con el entrypoint por defecto que proporciona Spring Security. Este entrypoint maneja las excepciones de una forma bastante simple: ocurra lo que ocurra, devuelve un `403 Forbidden` con un mensaje genérico.

Con este nuevo entrypoint, cada uno de los posibles fallos de seguridad estará manejado, por lo que los mensajes de error de cara al usuario serán más específicos y orientativos sobre lo que verdaderamente está pasando.

