### PR TITLE
feat: jwt filter integration tests

### DIFF
--- a/src/main/kotlin/com/esosa/f5pi_backend/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/config/SecurityConfig.kt
@@ -27,9 +27,9 @@ class SecurityConfig(
         jwtAuthenticationFilter: JWTAuthenticationFilter
     ) : SecurityFilterChain =
         http
-            .csrf { csrf -> csrf.disable() }
-            .authorizeHttpRequests { httpRequests ->
-                httpRequests
+            .csrf { it.disable() }
+            .authorizeHttpRequests {
+                it
                     .requestMatchers(*WHITE_LIST_URLS, *SWAGGER_URLS).permitAll()
                     .requestMatchers(HttpMethod.GET, "api/v1/**").permitAll()
                     .anyRequest().authenticated()

--- a/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/DemoController.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/controllers/implementations/DemoController.kt
@@ -1,0 +1,13 @@
+package com.esosa.f5pi_backend.controllers.implementations
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("api/v1/demo")
+class DemoController {
+
+    @GetMapping("ping")
+    fun ping(): String = "pong"
+}

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/entrypoint/JWTAuthEntryPoint.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/entrypoint/JWTAuthEntryPoint.kt
@@ -8,8 +8,8 @@ import com.esosa.f5pi_backend.security.utils.Constants.Companion.MISSING_HEADER_
 import com.esosa.f5pi_backend.security.utils.Constants.Companion.SIGNATURE_EXCEPTION_MESSAGE
 import com.esosa.f5pi_backend.security.utils.Constants.Companion.USERNAME_NOT_FOUND_MESSAGE
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.jsonwebtoken.ClaimJwtException
 import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.MalformedJwtException
 import io.jsonwebtoken.security.SignatureException
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -60,7 +60,7 @@ class JWTAuthEntryPoint(private val objectMapper: ObjectMapper) : Authentication
         return when (throwable) {
             is ExpiredJwtException -> EXPIRED_JWT_EXCEPTION_MESSAGE
             is SignatureException -> SIGNATURE_EXCEPTION_MESSAGE
-            is ClaimJwtException -> CLAIMS_JWT_EXCEPTION_MESSAGE
+            is MalformedJwtException -> CLAIMS_JWT_EXCEPTION_MESSAGE
             is IllegalArgumentException -> MISSING_HEADER_EXCEPTION_MESSAGE
             is UsernameNotFoundException -> USERNAME_NOT_FOUND_MESSAGE
             else -> JWT_EXCEPTION_DEFAULT_MESSAGE

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/filter/JWTAuthenticationFilter.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/filter/JWTAuthenticationFilter.kt
@@ -11,6 +11,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.apache.http.HttpHeaders.AUTHORIZATION
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.core.context.SecurityContextHolder
@@ -22,11 +23,15 @@ import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
 class JWTAuthenticationFilter(
-    private val userDetailsService: CustomUserDetailsService,
+    @Qualifier("customUserDetailsService") private val userDetailsService: CustomUserDetailsService,
     private val jwtService: JWTService,
     private val pathMatcher: AntPathMatcher,
     private val entryPoint: JWTAuthEntryPoint
 ) : OncePerRequestFilter() {
+
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
+    }
 
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -49,7 +54,7 @@ class JWTAuthenticationFilter(
     private fun authenticateRequest(request: HttpServletRequest) {
         val authHeader = request.getValidAuthHeader()
         val token = authHeader.extractToken()
-        val username = runCatchingAuthException { jwtService.extractUsernameFromToken(token) }
+        val username = jwtService.extractUsernameFromToken(token)
         val user = runCatchingAuthException { userDetailsService.loadUserByUsername(username) }
 
         if (jwtService.isTokenValid(token, user))
@@ -58,14 +63,14 @@ class JWTAuthenticationFilter(
 
     private fun HttpServletRequest.getValidAuthHeader(): String =
         getHeader(AUTHORIZATION)
-            ?.takeIf { it.startsWith("Bearer ") }
+            ?.takeIf { it.startsWith(BEARER_PREFIX) }
             ?: throw JWTAuthException(
                 MISSING_HEADER_EXCEPTION_MESSAGE.first,
                 IllegalArgumentException("Authorization header is missing or invalid")
             )
 
     private fun String.extractToken(): String =
-        substringAfter("Bearer ").takeIf { it.isNotBlank() }
+        substringAfter(BEARER_PREFIX).takeIf { it.isNotBlank() }
             ?: throw IllegalStateException("Invalid JWT format")
 
     private fun updateContext(user: UserDetails, request: HttpServletRequest) {

--- a/src/main/kotlin/com/esosa/f5pi_backend/security/service/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/esosa/f5pi_backend/security/service/CustomUserDetailsService.kt
@@ -1,20 +1,21 @@
 package com.esosa.f5pi_backend.security.service
 
 import com.esosa.f5pi_backend.data.repositories.IUserRepository
+import org.springframework.security.core.userdetails.User
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
-import org.springframework.security.core.userdetails.User
 
 typealias AppUser = com.esosa.f5pi_backend.data.models.User
 
-@Service
+@Service("customUserDetailsService")
 class CustomUserDetailsService(private val userRepository: IUserRepository) : UserDetailsService {
-    override fun loadUserByUsername(username: String): UserDetails =
-        userRepository.findByUsername(username)
+    override fun loadUserByUsername(username: String): UserDetails {
+        return userRepository.findByUsername(username)
             ?.mapToUserDetails()
             ?: throw UsernameNotFoundException("Username not found")
+    }
 
     private fun AppUser.mapToUserDetails() =
         User.builder()

--- a/src/test/kotlin/com/esosa/f5pi_backend/controllers/security/JWTFilterTest.kt
+++ b/src/test/kotlin/com/esosa/f5pi_backend/controllers/security/JWTFilterTest.kt
@@ -1,0 +1,99 @@
+package com.esosa.f5pi_backend.controllers.security
+
+import com.esosa.f5pi_backend.security.jwt.JWTService
+import com.esosa.f5pi_backend.security.service.CustomUserDetailsService
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.CLAIMS_JWT_EXCEPTION_MESSAGE
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.MISSING_HEADER_EXCEPTION_MESSAGE
+import com.esosa.f5pi_backend.security.utils.Constants.Companion.USERNAME_NOT_FOUND_MESSAGE
+import io.jsonwebtoken.MalformedJwtException
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class JWTFilterTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @MockBean
+    private lateinit var jwtService: JWTService
+
+    @MockBean(name = "customUserDetailsService")
+    private lateinit var customUserDetailsService: CustomUserDetailsService
+
+    companion object {
+        private const val TEST_TOKEN = "jwt.auth.token"
+        private const val TEST_USERNAME = "jwt.username"
+        private const val TEST_ENDPOINT = "/api/v1/demo/ping"
+    }
+
+    @Test
+    fun `should allow access with valid JWT`() {
+        setupValidJwtFlow()
+        mockMvc.perform(
+            get(TEST_ENDPOINT).withBearerToken(TEST_TOKEN)
+        ).andExpect(status().isOk)
+    }
+
+    @Test
+    fun `should deny access with no auth header`() {
+        mockMvc.perform(get(TEST_ENDPOINT))
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.message").value(containsString(MISSING_HEADER_EXCEPTION_MESSAGE.first)))
+    }
+
+    @Test
+    fun `should deny access with malformed JWT`() {
+        setupMalformedJwtFlow()
+        mockMvc.perform(
+            get(TEST_ENDPOINT).withBearerToken(TEST_TOKEN)
+        ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.message").value(containsString(CLAIMS_JWT_EXCEPTION_MESSAGE.first)))
+    }
+
+    @Test
+    fun `should deny access with non existent user`() {
+        setupNonExistentUserFlow()
+        mockMvc.perform(
+            get(TEST_ENDPOINT).withBearerToken(TEST_TOKEN)
+        ).andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.message").value(containsString(USERNAME_NOT_FOUND_MESSAGE.first)))
+    }
+
+    private fun setupValidJwtFlow() {
+        val userDetails = mock<UserDetails>()
+        whenever(jwtService.extractUsernameFromToken(eq(TEST_TOKEN))).thenReturn(TEST_USERNAME)
+        whenever(customUserDetailsService.loadUserByUsername(TEST_USERNAME)).thenReturn(userDetails)
+        whenever(jwtService.isTokenValid(TEST_TOKEN, userDetails)).thenReturn(true)
+    }
+
+    private fun setupMalformedJwtFlow() {
+        whenever(jwtService.extractUsernameFromToken(TEST_TOKEN))
+            .thenThrow(MalformedJwtException("Malformed JWT"))
+    }
+
+    private fun setupNonExistentUserFlow() {
+        whenever(jwtService.extractUsernameFromToken(eq(TEST_TOKEN))).thenReturn(TEST_USERNAME)
+        whenever(customUserDetailsService.loadUserByUsername(TEST_USERNAME))
+            .thenThrow(UsernameNotFoundException("Username not found"))
+    }
+
+    private fun MockHttpServletRequestBuilder.withBearerToken(token: String) =
+        header(AUTHORIZATION, "Bearer $token")
+}


### PR DESCRIPTION
## Descripción

Se agregaron tests de integración que prueban nuestro `JWTAuthenticationFilter`, utilizado para determinar si un usuario está autenticado o no. Estos tests se enfocan, particularmente, en el lanzado de excepciones en distintos puntos del `doFilter` y en su manejo en el `JWTAuthEntryPoint`.

## Reflexión sumamente trascendental

Haciendo los tests me di cuenta de que el esquema de autenticación puede mejorarse muchísimo, tanto en cuestiones de performance como en cuestiones de arquitectura. Sólo con dos cambios simples la aplicación funcionaría muchísimo mejor:

1. Desacoplar el `JWTService` del model `UserDetails`. Únicamente se utiliza el username (subject), por lo que, recibiendo únicamente ese atributo por parámetro evitamos ejecutar el `userDetailsService.loadUserByUsername` cada vez que queremos realizar una operación relacionada al token.
2. Dividir el `UserService` en dos servicios con responsabilidades únicas: un servicio que maneje las operaciones nativas a los usuarios (alta, baja, modificación y eliminación) y otro servicio, un `UserDataService`, que maneje la información de otras entidades relacionadas a los usuarios (partidos, canchas, jugadores y temporadas). Con esto, resolvemos el ciclo de dependencias de una forma más elegante que con un `@Lazy` que sirve como parche.